### PR TITLE
Better coverage of mul high instructions

### DIFF
--- a/isa/rv32ui/mul.S
+++ b/isa/rv32ui/mul.S
@@ -31,6 +31,12 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP(30,  mul, 0x0000ff7f, 0xaaaaaaab, 0x0002fe7d );
   TEST_RR_OP(31,  mul, 0x0000ff7f, 0x0002fe7d, 0xaaaaaaab );
 
+  TEST_RR_OP(34,  mul, 0x00000000, 0xff000000, 0xff000000 );
+
+  TEST_RR_OP(35,  mul, 0x00000001, 0xffffffff, 0xffffffff );
+  TEST_RR_OP(36,  mul, 0xffffffff, 0xffffffff, 0x00000001 );
+  TEST_RR_OP(37,  mul, 0xffffffff, 0x00000001, 0xffffffff );
+
   #-------------------------------------------------------------
   # Source/Destination tests
   #-------------------------------------------------------------

--- a/isa/rv32ui/mulh.S
+++ b/isa/rv32ui/mulh.S
@@ -25,15 +25,14 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP( 6,  mulh, 0x00000000, 0x80000000, 0x00000000 );
   TEST_RR_OP( 7,  mulh, 0x00000000, 0x80000000, 0x00000000 );
 
-  TEST_RR_OP(30,  mulh, 0xfffe0101, 0xaaaaaaab, 0x0002fe7d );
-  TEST_RR_OP(31,  mulh, 0xfffe0101, 0x0002fe7d, 0xaaaaaaab );
+  TEST_RR_OP(30,  mulh, 0xffff0081, 0xaaaaaaab, 0x0002fe7d );
+  TEST_RR_OP(31,  mulh, 0xffff0081, 0x0002fe7d, 0xaaaaaaab );
 
-  TEST_RR_OP(32,  mulh, 0xfe010000, 0xff000000, 0xff000000 );
+  TEST_RR_OP(32,  mulh, 0x00010000, 0xff000000, 0xff000000 );
 
-  TEST_RR_OP(33,  mulh, 0xfffffffe, 0xffffffff, 0xffffffff );
+  TEST_RR_OP(33,  mulh, 0x00000000, 0xffffffff, 0xffffffff );
   TEST_RR_OP(34,  mulh, 0xffffffff, 0xffffffff, 0x00000001 );
   TEST_RR_OP(35,  mulh, 0xffffffff, 0x00000001, 0xffffffff );
-
 
   #-------------------------------------------------------------
   # Source/Destination tests

--- a/isa/rv32ui/mulh.S
+++ b/isa/rv32ui/mulh.S
@@ -25,6 +25,16 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP( 6,  mulh, 0x00000000, 0x80000000, 0x00000000 );
   TEST_RR_OP( 7,  mulh, 0x00000000, 0x80000000, 0x00000000 );
 
+  TEST_RR_OP(30,  mulh, 0xfffe0101, 0xaaaaaaab, 0x0002fe7d );
+  TEST_RR_OP(31,  mulh, 0xfffe0101, 0x0002fe7d, 0xaaaaaaab );
+
+  TEST_RR_OP(32,  mulh, 0xfe010000, 0xff000000, 0xff000000 );
+
+  TEST_RR_OP(33,  mulh, 0xfffffffe, 0xffffffff, 0xffffffff );
+  TEST_RR_OP(34,  mulh, 0xffffffff, 0xffffffff, 0x00000001 );
+  TEST_RR_OP(35,  mulh, 0xffffffff, 0x00000001, 0xffffffff );
+
+
   #-------------------------------------------------------------
   # Source/Destination tests
   #-------------------------------------------------------------

--- a/isa/rv32ui/mulhsu.S
+++ b/isa/rv32ui/mulhsu.S
@@ -25,12 +25,12 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP( 6,  mulhsu, 0x00000000, 0x80000000, 0x00000000 );
   TEST_RR_OP( 7,  mulhsu, 0x80004000, 0x80000000, 0xffff8000 );
 
-  TEST_RR_OP(30,  mulhsu, 0xfffe0101, 0xaaaaaaab, 0x0002fe7d );
+  TEST_RR_OP(30,  mulhsu, 0xffff0081, 0xaaaaaaab, 0x0002fe7d );
   TEST_RR_OP(31,  mulhsu, 0x0001fefe, 0x0002fe7d, 0xaaaaaaab );
 
-  TEST_RR_OP(32,  mulhsu, 0x01ff0000, 0xff000000, 0xff000000 );
+  TEST_RR_OP(32,  mulhsu, 0xff010000, 0xff000000, 0xff000000 );
 
-  TEST_RR_OP(33,  mulhsu, 0x00000001, 0xffffffff, 0xffffffff );
+  TEST_RR_OP(33,  mulhsu, 0xffffffff, 0xffffffff, 0xffffffff );
   TEST_RR_OP(34,  mulhsu, 0xffffffff, 0xffffffff, 0x00000001 );
   TEST_RR_OP(35,  mulhsu, 0x00000000, 0x00000001, 0xffffffff );
 

--- a/isa/rv32ui/mulhsu.S
+++ b/isa/rv32ui/mulhsu.S
@@ -25,6 +25,15 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP( 6,  mulhsu, 0x00000000, 0x80000000, 0x00000000 );
   TEST_RR_OP( 7,  mulhsu, 0x80004000, 0x80000000, 0xffff8000 );
 
+  TEST_RR_OP(30,  mulhsu, 0xfffe0101, 0xaaaaaaab, 0x0002fe7d );
+  TEST_RR_OP(31,  mulhsu, 0x0001fefe, 0x0002fe7d, 0xaaaaaaab );
+
+  TEST_RR_OP(32,  mulhsu, 0x01ff0000, 0xff000000, 0xff000000 );
+
+  TEST_RR_OP(33,  mulhsu, 0x00000001, 0xffffffff, 0xffffffff );
+  TEST_RR_OP(34,  mulhsu, 0xffffffff, 0xffffffff, 0x00000001 );
+  TEST_RR_OP(35,  mulhsu, 0x00000000, 0x00000001, 0xffffffff );
+
   #-------------------------------------------------------------
   # Source/Destination tests
   #-------------------------------------------------------------

--- a/isa/rv32ui/mulhu.S
+++ b/isa/rv32ui/mulhu.S
@@ -28,6 +28,12 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP(30,  mulhu, 0x0001fefe, 0xaaaaaaab, 0x0002fe7d );
   TEST_RR_OP(31,  mulhu, 0x0001fefe, 0x0002fe7d, 0xaaaaaaab );
 
+  TEST_RR_OP(32,  mulhu, 0xfe010000, 0xff000000, 0xff000000 );
+
+  TEST_RR_OP(33,  mulhu, 0xfffffffe, 0xffffffff, 0xffffffff );
+  TEST_RR_OP(34,  mulhu, 0x00000000, 0xffffffff, 0x00000001 );
+  TEST_RR_OP(35,  mulhu, 0x00000000, 0x00000001, 0xffffffff );
+
   #-------------------------------------------------------------
   # Source/Destination tests
   #-------------------------------------------------------------


### PR DESCRIPTION
My riscv implementation passed both mulh and mulhu without me having implemented signed behaviour in my multiplication unit.
