### PR TITLE
Two extra NaN test cases

### DIFF
--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -500,6 +500,14 @@ test_ ## testnum: \
   TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, 0.0, 0.0, \
                     inst f3, f0; fmv.x.d a0, f3)
 
+#define TEST_FP_OP1_S_DWORD_RESULT( testnum, inst, flags, result, val1 ) \
+  TEST_FP_OP_S_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
+                    inst f3, f0; fmv.x.s a0, f3)
+
+#define TEST_FP_OP1_D_DWORD_RESULT( testnum, inst, flags, result, val1 ) \
+  TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
+                    inst f3, f0; fmv.x.d a0, f3)
+
 #define TEST_FP_OP2_S( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, val2, 0.0, \
                     inst f3, f0, f1; fmv.x.s a0, f3)

--- a/isa/rv64uf/fcvt.S
+++ b/isa/rv64uf/fcvt.S
@@ -44,6 +44,15 @@ RVTEST_CODE_BEGIN
   TEST_FCVT_S_D(20, -1.5, -1.5)
   TEST_FCVT_D_S(21, -1.5, -1.5)
 
+  TEST_CASE(22, a0, 0x7ff8000000000000,
+    la a1, test_data_22;
+    ld a2, 0(a1);
+    fmv.d.x f2, a2;
+    fcvt.s.d f2, f2;
+    fcvt.d.s f2, f2;
+    fmv.x.d a0, f2;
+  )
+
   TEST_PASSFAIL
 
 RVTEST_CODE_END
@@ -52,5 +61,8 @@ RVTEST_CODE_END
 RVTEST_DATA_BEGIN
 
   TEST_DATA
+
+test_data_22:
+  .dword 0x7ffcffffffff8004
 
 RVTEST_DATA_END

--- a/isa/rv64uf/fdiv.S
+++ b/isa/rv64uf/fdiv.S
@@ -31,6 +31,9 @@ RVTEST_CODE_BEGIN
   TEST_FP_OP1_D(13,  fsqrt.d, 1, 1.7724538498928541, 3.14159265 );
   TEST_FP_OP1_D(14,  fsqrt.d, 0,                100,      10000 );
 
+  TEST_FP_OP1_S_DWORD_RESULT(15,  fsqrt.s, 0x10,              0x7FC00000,      -1.0 );
+  TEST_FP_OP1_D_DWORD_RESULT(16,  fsqrt.d, 0x10,      0x7FF8000000000000,      -1.0 );
+
   TEST_PASSFAIL
 
 RVTEST_CODE_END


### PR DESCRIPTION
I've been experiencing some differences between Spike and Rocket when trying to run riscv-torture that look like they're related to NaNs.  These test cases add a few arbitrary NaNs to the ISA tests that I happened to write when trying to figure out what was going on.