### PR TITLE
Add a "--with-xlen" configure argument

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,5 +1,6 @@
 prefix          := @prefix@
 abs_top_src_dir := @abs_top_srcdir@
+XLEN            := @XLEN@
 instbasedir     := $(DESTDIR)$(prefix)
 bmarkdir        := $(abs_top_src_dir)/benchmarks
 isa_src_dir     := $(abs_top_src_dir)/isa
@@ -14,11 +15,11 @@ install: all
 
 benchmarks:
 	mkdir -p benchmarks
-	$(MAKE) -C benchmarks -f $(bmarkdir)/Makefile src_dir=$(bmarkdir)
+	$(MAKE) -C benchmarks -f $(bmarkdir)/Makefile src_dir=$(bmarkdir) XLEN=$(XLEN)
 
 isa:
 	mkdir -p isa
-	$(MAKE) -C isa -f $(isa_src_dir)/Makefile src_dir=$(isa_src_dir)
+	$(MAKE) -C isa -f $(isa_src_dir)/Makefile src_dir=$(isa_src_dir) XLEN=$(XLEN)
 
 clean:
 	$(MAKE) -C isa -f $(isa_src_dir)/Makefile src_dir=$(isa_src_dir) clean

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -46,7 +46,7 @@ bmarks_host = \
 HOST_OPTS = -std=gnu99 -DPREALLOCATE=0 -DHOST_DEBUG=1
 HOST_COMP = gcc $(HOST_OPTS)
 
-RISCV_PREFIX ?= riscv64-unknown-elf-
+RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
 RISCV_GCC ?= $(RISCV_PREFIX)gcc
 RISCV_GCC_OPTS ?= -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf
 RISCV_LINK ?= $(RISCV_GCC) -T $(src_dir)/common/test.ld $(incs)

--- a/configure
+++ b/configure
@@ -583,6 +583,7 @@ PACKAGE_URL=''
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+XLEN
 OBJEXT
 EXEEXT
 ac_ct_CC
@@ -631,6 +632,7 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+with_xlen
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1244,6 +1246,11 @@ if test -n "$ac_init_help"; then
      short | recursive ) echo "Configuration of riscv-tests 1.0:";;
    esac
   cat <<\_ACEOF
+
+Optional Packages:
+  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-xlen=XLEN        Set XLEN, the X-register bit width (default is 64)
 
 Some influential environment variables:
   CC          C compiler command
@@ -2513,6 +2520,19 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+
+# Check whether --with-xlen was given.
+if test "${with_xlen+set}" = set; then :
+  withval=$with_xlen; XLEN=$withval
+
+else
+  XLEN=64
+
+
+fi
+
 
 
 ac_config_files="$ac_config_files Makefile"

--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,14 @@ AC_INIT(riscv-tests, 1.0)
 cross_compiling=yes
 AC_PROG_CC
 
+AC_ARG_WITH(xlen,
+        [AS_HELP_STRING([--with-xlen=XLEN],
+                [Set XLEN, the X-register bit width (default is 64)])],
+        AC_SUBST(XLEN, $withval),
+        AC_SUBST(XLEN, 64)
+        )
+
+
 AC_OUTPUT(
     Makefile
 )

--- a/isa/Makefile
+++ b/isa/Makefile
@@ -23,13 +23,12 @@ default: all
 # Build rules
 #--------------------------------------------------------------------
 
-RISCV_PREFIX ?= riscv64-unknown-elf-
+RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
 RISCV_GCC ?= $(RISCV_PREFIX)gcc
 ENTROPY ?= -DENTROPY=$(shell echo $$$$)
 RISCV_GCC_OPTS ?= $(ENTROPY) -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
 RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data
 RISCV_SIM ?= spike
-XLEN ?= 64
 
 vpath %.S $(src_dir)
 

--- a/mt/Makefile
+++ b/mt/Makefile
@@ -75,7 +75,7 @@ bmarks = $(bmarks_vvadd) $(bmarks_matmul)
 # Build rules
 #--------------------------------------------------------------------
 
-RISCV_PREFIX=riscv64-unknown-elf-
+RISCV_PREFIX=riscv$(XLEN)-unknown-elf-
 RISCV_GCC = $(RISCV_PREFIX)gcc
 RISCV_GCC_OPTS = -std=gnu99 -O2 -ffast-math
 RISCV_LINK = $(RISCV_GCC) -T $(common)/test.ld $(incs)


### PR DESCRIPTION
The tools had riscv64-unknown-elf-gcc hard-coded all over the place.
This lets users override that if they have a 32-bit toolchain.