### PR TITLE
Display log file during build if debug testing fails.

### DIFF
--- a/debug/Makefile
+++ b/debug/Makefile
@@ -8,11 +8,9 @@ default:	spike$(XLEN).log
 
 all:	spike32.log spike64.log
 
-spike32.log:
-	$(GDBSERVER_PY) --isolate --spike32 --cmd $(RISCV_SIM) -- -v > $@ 2>&1
-
-spike64.log:
-	$(GDBSERVER_PY) --isolate --spike --cmd $(RISCV_SIM) -- -v > $@ 2>&1
+%.log:
+	$(GDBSERVER_PY) --isolate --$(subst .log,,$@) --cmd $(RISCV_SIM) -- -v \
+	    > $@ 2>&1 || sed s/^/$@:\ / $@
 
 clean:
 	rm -f *.log

--- a/debug/README.md
+++ b/debug/README.md
@@ -12,7 +12,7 @@ Targets
 64-bit Spike
 ------------
 
-`./gdbserver.py --spike --cmd $RISCV/bin/spike`
+`./gdbserver.py --spike64 --cmd $RISCV/bin/spike`
 
 32-bit Spike
 ------------
@@ -28,7 +28,7 @@ Debug Tips
 ==========
 
 You can run just a single test by specifying <class>.<function> on the command
-line, eg: `./gdbserver.py --spike --cmd $RISCV/bin/spike
+line, eg: `./gdbserver.py --spike64 --cmd $RISCV/bin/spike
 SimpleRegisterTest.test_s0`.
 Once that test has failed, you can look at gdb.log and (in this case) spike.log
 to get an idea of what might have gone wrong.

--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -484,25 +484,23 @@ class Target(object):
                 xlen=self.xlen)
         return binary_name
 
-class Spike64Target(Target):
-    name = "spike"
-    xlen = 64
+class SpikeTarget(Target):
+    directory = "spike"
     ram = 0x80010000
     ram_size = 5 * 1024 * 1024
     instruction_hardware_breakpoint_count = 0
     reset_vector = 0x1000
+
+class Spike64Target(SpikeTarget):
+    name = "spike64"
+    xlen = 64
 
     def server(self):
         return testlib.Spike(parsed.cmd, halted=True)
 
-class Spike32Target(Target):
+class Spike32Target(SpikeTarget):
     name = "spike32"
-    directory = "spike"
     xlen = 32
-    ram = 0x80010000
-    ram_size = 5 * 1024 * 1024
-    instruction_hardware_breakpoint_count = 0
-    reset_vector = 0x1000
 
     def server(self):
         return testlib.Spike(parsed.cmd, halted=True, xlen=32)


### PR DESCRIPTION
That way somebody doesn't need to spend forever trying to reproduce a
travis failure when all they really need is the logfile.