### PR TITLE
Use port randomization for VCS and OpenOCD

### DIFF
--- a/debug/targets/freedom-e300-sim/openocd.cfg
+++ b/debug/targets/freedom-e300-sim/openocd.cfg
@@ -1,6 +1,7 @@
 adapter_khz     10000
 
 source [find interface/jtag_vpi.cfg]
+jtag_vpi_set_port $::env(JTAG_VPI_PORT)
 
 set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913

--- a/debug/targets/freedom-u500-sim/openocd.cfg
+++ b/debug/targets/freedom-u500-sim/openocd.cfg
@@ -1,6 +1,7 @@
 adapter_khz     10000
 
 source [find interface/jtag_vpi.cfg]
+jtag_vpi_set_port $::env(JTAG_VPI_PORT)
 
 set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -129,13 +129,19 @@ class Openocd(object):
             cmd += ["-f", find_file(config)]
         if debug:
             cmd.append("-d")
+
+        # Assign port
+        self.port = unused_port()
+        print "Using port %d for gdb server" % self.port
+        # This command needs to come before any config scripts on the command
+        # line, since they are executed in order.
+        cmd[1:1] = ["--command", "gdb_port %d" % self.port]
+
         logfile = open(Openocd.logname, "w")
         logfile.write("+ %s\n" % " ".join(cmd))
         logfile.flush()
         self.process = subprocess.Popen(cmd, stdin=subprocess.PIPE,
                 stdout=logfile, stderr=logfile)
-        # TODO: Pick a random port
-        self.port = 3333
 
         # Wait for OpenOCD to have made it through riscv_examine(). When using
         # OpenOCD to communicate with a simulator this may take a long time,


### PR DESCRIPTION
@timsifive @yunsup @mwachs5 

Here are the changes we made internally at SiFive to the JTAG debugging code in order to allow us to run multiple processes at the same time. It consists of two parts:

1. Dynamically grabbing the JTAG VPI port number from VCS by parsing the output, instead of assuming it is on port 5555, and telling OpenOCD to connect to that port via environment variable.
2. Telling OpenOCD to use a randomly selected port for the GDB server.

@yunsup, this differs slightly from what we built internally in that instead of having `testlib.py` pick which port the JTAG VPI should use, I modified the `jtag_vpi.c` code to obtain a random port, and now `testlib.py` merely parses out the chosen port and passes it to OpenOCD. I'm able to get this to work locally on the SiFive internal tests, and I'll need to submit one followup PR to rocket-chip to update the `jtag_vpi.c` module to randomly pick a port.
