### PR TITLE
Tell OpenOCD to pick an unused port for gdb server

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -161,7 +161,7 @@ class Openocd(object):
 
     def _get_gdb_server_port(self):
         """Get port that OpenOCD's gdb server is listening on."""
-        MAX_ATTEMPTS = 5
+        MAX_ATTEMPTS = 50
         PORT_REGEX = re.compile(r'(?P<port>\d+) \(LISTEN\)')
         for _ in range(MAX_ATTEMPTS):
             with open(os.devnull, 'w') as devnull:
@@ -179,7 +179,7 @@ class Openocd(object):
             elif matches:
                 [match] = matches
                 return int(match.group('port'))
-            time.sleep(1)
+            time.sleep(0.1)
         raise Exception("Timed out waiting for gdb server to obtain port.")
 
     def __del__(self):


### PR DESCRIPTION
@timsifive @mwachs5 

We're still occasionally running into this spurious error in our internal CI system:

```pytb
Running SimpleS0Test ... Waiting for OpenOCD to examine RISCV core...
Traceback (most recent call last):
  File "rocket-chip/riscv-tools/riscv-tests/debug/gdbserver.py", line 710, in <module>
    sys.exit(main())
  File "rocket-chip/riscv-tools/riscv-tests/debug/gdbserver.py", line 702, in main
    return testlib.run_all_tests(module, target, parsed.test, parsed.fail_fast)
  File "rocket-chip/riscv-tools/riscv-tests/debug/testlib.py", line 287, in run_all_tests
    result = instance.run()
  File "rocket-chip/riscv-tools/riscv-tests/debug/testlib.py", line 384, in run
    self.classSetup()
  File "rocket-chip/riscv-tools/riscv-tests/debug/gdbserver.py", line 97, in classSetup
    self.gdb = gdb(self.target, self.server.port, self.binary)
  File "rocket-chip/riscv-tools/riscv-tests/debug/gdbserver.py", line 57, in gdb
    g.p("$priv=3")
  File "rocket-chip/riscv-tools/riscv-tests/debug/testlib.py", line 246, in p
    value = int(output.split('=')[-1].strip(), 0)
ValueError: invalid literal for int() with base 0: 'No registers.'
```

When inspecting `openocd.log`, you can see this at the bottom:

```
Error: 482 28849 server.c:265 add_service(): couldn't bind tcl to socket: Address already in use
```

This leads me to believe that the issue is with a race condition between `gdbserver.py` picking an unused port and OpenOCD binding to that port, whereby another process on the machine may bind to the port in between the two events.

This PR changes `testlib.py` to pass in the command `gdb_port 0` to OpenOCD, which tells OpenOCD to bind to a random unused port. One problem is that OpenOCD itself doesn't understand that making a syscall to bind to port 0 means that the OS will bind to a random port, so all of OpenOCD's logs just say that it's binding to port 0. In order to figure out which port was actually assign, I used `lsof` on the subprocess's open sockets and assert that there should be exactly one socket listening on a port.

Let me know if you can think of a better way of doing this, since it does feel a little bit messy.

Unrelated, but when I try to run the tests, they fail on `SimpleF18Test`, even when I'm on master. I tried making sure that I'm using the latest version of `riscv-isa-sim`, but that didn't seem to fix it.