### PR TITLE
Disable tcl and telnet servers when running OpenOCD

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -140,8 +140,18 @@ class Openocd(object):
 
         # This command needs to come before any config scripts on the command
         # line, since they are executed in order.
-        # Tell OpenOCD to bind to an unused port.
-        cmd[1:1] = ["--command", "gdb_port %d" % 0]
+        cmd[1:1] = [
+            # Tell OpenOCD to bind gdb to an unused, ephemeral port.
+            "--command",
+            "gdb_port 0",
+            # Disable tcl and telnet servers, since they are unused and because
+            # the port numbers will conflict if multiple OpenOCD processes are
+            # running on the same server.
+            "--command",
+            "tcl_port disabled",
+            "--command",
+            "telnet_port disabled",
+        ]
 
         logfile = open(Openocd.logname, "w")
         logfile.write("+ %s\n" % " ".join(cmd))


### PR DESCRIPTION
Hi @timsifive, I am hoping that this will be the last of the changes I need to make in order to make it safe to run multiple `gdbserver.py` processes on the same machine. We're still occasionally getting port conflict errors, even with my last set of changes. Looking at `openocd.log` more carefully, I realized that it wasn't actually a conflict with the gdb server, but instead the tcl server that OpenOCD starts up:

```
Error: 482 29163 server.c:265 add_service(): couldn't bind tcl to socket: Address already in use
```

I realized that by default, OpenOCD starts up both a tcl server and a telnet server which allow you to issue tcl commands to OpenOCD, and which bind to ports 6666 and 4444 respectively. The problem is that if you have multiple processes running OpenOCD, you get conflicts on these ports, even though they're not really being used.

In this PR, I've updated the OpenOCD wrapper class with a couple more commands to disable both the tcl and telnet servers, and I checked that this still runs correctly with the local tests that use this script.