### PR TITLE
debug: check that reading nonexistent CSR returns error.

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -570,9 +570,18 @@ class WriteCsrs(RegsTest):
 class NonExistentCsr(RegsTest):
     def test(self):
         #Print old version of $misa at 0xF10 (moved to 0x301)
-        self.gdb.p("$csr3856")
-        #Expect this to return an error, not just a made-up value.
-        assertIn("Could not fetch register", output)
+        try:
+            self.gdb.p("$csr3856")
+            assert False, "Nonexistent CSR read should have failed."
+        except testlib.CannotAccessRegister as e:
+            assertEqual(e.regname, "csr3856")
+
+        #Try to write $misa in its old location
+        try:
+            self.gdb.p("$csr3856")
+            assert False, "Nonexistent CSR write should have failed."
+        except testlib.CannotAccessRegister as e:
+            assertEqual(e.regname, "csr3856")
 
 class DownloadTest(GdbTest):
     def setup(self):

--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -567,6 +567,13 @@ class WriteCsrs(RegsTest):
         assertEqual(123, self.gdb.p("$x1"))
         assertEqual(123, self.gdb.p("$csr832"))
 
+class NonExistentCsr(RegsTest):
+    def test(self):
+        #Print old version of $misa at 0xF10 (moved to 0x301)
+        self.gdb.p("$csr3856")
+        #Expect this to return an error, not just a made-up value.
+        assertIn("Could not fetch register", output)
+
 class DownloadTest(GdbTest):
     def setup(self):
         # pylint: disable=attribute-defined-outside-init

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -228,6 +228,9 @@ class OpenocdCli(object):
 
     def reg(self, reg=''):
         output = self.command("reg %s" % reg)
+        m = re.search(r'Could not fetch register "(\w+)"', output)
+        if m:
+            raise CannotAccessRegister(m.group(1))
         matches = re.findall(r"(\w+) \(/\d+\): (0x[0-9A-F]+)", output)
         values = {r: int(v, 0) for r, v in matches}
         if reg:
@@ -243,6 +246,11 @@ class CannotAccess(Exception):
     def __init__(self, address):
         Exception.__init__(self)
         self.address = address
+
+class CannotAccessRegister(Exception):
+    def __init__(self, regname):
+        Exception.__init__(self)
+        self.regname = regname
 
 class Gdb(object):
     def __init__(self,
@@ -291,6 +299,9 @@ class Gdb(object):
         m = re.search("Cannot access memory at address (0x[0-9a-f]+)", output)
         if m:
             raise CannotAccess(int(m.group(1), 0))
+        m = re.search(r'Could not fetch register "(\w+)"', output)
+        if m:
+            raise CannotAccessRegister(m.group(1))
         return output.split('=')[-1].strip()
 
     def p(self, obj):
@@ -298,6 +309,9 @@ class Gdb(object):
         m = re.search("Cannot access memory at address (0x[0-9a-f]+)", output)
         if m:
             raise CannotAccess(int(m.group(1), 0))
+        m = re.search(r'Could not fetch register "(\w+)"', output)
+        if m:
+            raise CannotAccessRegister(m.group(1))
         value = int(output.split('=')[-1].strip(), 0)
         return value
 


### PR DESCRIPTION
This isn't ready to merge, as it fails, and OpenOCD needs to be bumped.

@timsifive can you take a look? If I run this test with my new version of OpenOCD which returns errors, it does correctly print the expected string in the test log, but then the overall test fails. I think I'm not doing the actual `assertIn` correctly.