### PR TITLE
Two GP-related fixes

### DIFF
--- a/benchmarks/common/crt.S
+++ b/benchmarks/common/crt.S
@@ -108,7 +108,10 @@ _start:
 1:
 
   # initialize global pointer
+.option push
+.option norelax
   la gp, __global_pointer$
+.option pop
 
   la  tp, _end + 63
   and tp, tp, -64

--- a/benchmarks/common/crt.S
+++ b/benchmarks/common/crt.S
@@ -108,7 +108,7 @@ _start:
 1:
 
   # initialize global pointer
-  la gp, _gp
+  la gp, __global_pointer$
 
   la  tp, _end + 63
   and tp, tp, -64

--- a/benchmarks/common/test.ld
+++ b/benchmarks/common/test.ld
@@ -32,7 +32,7 @@ SECTIONS
   .data : { *(.data) }
 
   .sdata : {
-    _gp = . + 0x800;
+    __global_pointer$ = . + 0x800;
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2) *(.srodata*)
     *(.sdata .sdata.* .gnu.linkonce.s.*)
   }

--- a/debug/programs/entry.S
+++ b/debug/programs/entry.S
@@ -35,7 +35,7 @@ handle_reset:
   csrwi mie, 0
 
   # initialize global pointer
-  la gp, _gp
+  la gp, __global_pointer$
 
   # initialize stack pointer
   la sp, stack_top

--- a/debug/programs/entry.S
+++ b/debug/programs/entry.S
@@ -35,7 +35,10 @@ handle_reset:
   csrwi mie, 0
 
   # initialize global pointer
+.option push
+.option norelax
   la gp, __global_pointer$
+.option pop
 
   # initialize stack pointer
   la sp, stack_top

--- a/debug/targets/freedom-e300-sim/link.lds
+++ b/debug/targets/freedom-e300-sim/link.lds
@@ -13,7 +13,7 @@ SECTIONS
   .data : { *(.data) }
 
   .sdata : {
-    _gp = . + 0x800;
+    __global_pointer$ = . + 0x800;
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
     *(.srodata*)
     *(.sdata .sdata.* .gnu.linkonce.s.*)

--- a/debug/targets/freedom-e300/link.lds
+++ b/debug/targets/freedom-e300/link.lds
@@ -13,7 +13,7 @@ SECTIONS
   .data : { *(.data) }
 
   .sdata : {
-    _gp = . + 0x800;
+    __global_pointer$ = . + 0x800;
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
     *(.srodata*)
     *(.sdata .sdata.* .gnu.linkonce.s.*)

--- a/debug/targets/freedom-u500-sim/link.lds
+++ b/debug/targets/freedom-u500-sim/link.lds
@@ -13,7 +13,7 @@ SECTIONS
   .data : { *(.data) }
 
   .sdata : {
-    _gp = . + 0x800;
+    __global_pointer$ = . + 0x800;
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
     *(.srodata*)
     *(.sdata .sdata.* .gnu.linkonce.s.*)

--- a/debug/targets/freedom-u500/link.lds
+++ b/debug/targets/freedom-u500/link.lds
@@ -13,7 +13,7 @@ SECTIONS
   .data : { *(.data) }
 
   .sdata : {
-    _gp = . + 0x800;
+    __global_pointer$ = . + 0x800;
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
     *(.srodata*)
     *(.sdata .sdata.* .gnu.linkonce.s.*)

--- a/debug/targets/spike/link.lds
+++ b/debug/targets/spike/link.lds
@@ -15,7 +15,7 @@ SECTIONS
   .data : { *(.data) }
 
   .sdata : {
-    _gp = . + 0x800;
+    __global_pointer$ = . + 0x800;
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
     *(.srodata*)
     *(.sdata .sdata.* .gnu.linkonce.s.*)


### PR DESCRIPTION
The second one is a preemptive fix, the first one effectively turns GP back on (ld won't relax to it unless it's there, and the symbol name changed).