### PR TITLE
No Examine Target

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -371,8 +371,9 @@ def run_all_tests(module, target, parsed):
     gdb_cmd = parsed.gdb
 
     todo = []
-    if (parsed.misa):
-        self.target.misa = parsed.misa
+    if (parsed.misaval):
+        target.misa = int(parsed.misaval, 16)
+        print "Assuming $MISA value of 0x%x. Skipping ExamineTarget." % target.misa
     else:
         todo.append(("ExamineTarget", ExamineTarget))
 
@@ -402,15 +403,19 @@ def run_all_tests(module, target, parsed):
 
     return result
 
+def auto_int (x) :
+    return int(x, 0)
+
 def add_test_run_options(parser):
+
     parser.add_argument("--fail-fast", "-f", action="store_true",
             help="Exit as soon as any test fails.")
     parser.add_argument("test", nargs='*',
             help="Run only tests that are named here.")
     parser.add_argument("--gdb",
             help="The command to use to start gdb.")
-    parser.add_argument("--misa", "-m",
-            help="Don't run ExamineTarget, just assume the misa which is specified.")
+    parser.add_argument("--misaval",
+            help="Don't run ExamineTarget, just assume the misa value which is specified.")
 
 def header(title, dash='-'):
     if title:

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -370,7 +370,12 @@ def run_all_tests(module, target, parsed):
     global gdb_cmd  # pylint: disable=global-statement
     gdb_cmd = parsed.gdb
 
-    todo = [("ExamineTarget", ExamineTarget)]
+    todo = []
+    if (parsed.misa):
+        self.target.misa = parsed.misa
+    else:
+        todo.append(("ExamineTarget", ExamineTarget))
+
     for name in dir(module):
         definition = getattr(module, name)
         if type(definition) == type and hasattr(definition, 'test') and \
@@ -404,6 +409,8 @@ def add_test_run_options(parser):
             help="Run only tests that are named here.")
     parser.add_argument("--gdb",
             help="The command to use to start gdb.")
+    parser.add_argument("--misa", "-m",
+            help="Don't run ExamineTarget, just assume the misa which is specified.")
 
 def header(title, dash='-'):
     if title:

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -403,9 +403,6 @@ def run_all_tests(module, target, parsed):
 
     return result
 
-def auto_int (x) :
-    return int(x, 0)
-
 def add_test_run_options(parser):
 
     parser.add_argument("--fail-fast", "-f", action="store_true",


### PR DESCRIPTION
The whole purpose of ExamineTarget is to print out the $misa register. If that is all you want to do, before a quick test, can just specify the value you would have read on the command line and then run the single test.