### PR TITLE
Fail if simulator exits early.

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -132,6 +132,12 @@ class VcsSim(object):
                 stdout=logfile, stderr=logfile)
         done = False
         while not done:
+            # Fail if VCS exits early
+            exit_code = self.process.poll()
+            if exit_code is not None:
+                raise RuntimeError('VCS simulator exited early with status %d'
+                                   % exit_code)
+
             line = listenfile.readline()
             if not line:
                 time.sleep(1)


### PR DESCRIPTION
Currently, if VCS has an issue and crashes before setting up the JTAG VPI port, then `testlib.py` will hang indefinitely looking for the port number in the output. This adds a check to the port number polling loop to raise an exception if the process has exited before we see the port number.