### PR TITLE
Enable the RTOS when running tests on Spike

### DIFF
--- a/debug/targets/spike/openocd.cfg
+++ b/debug/targets/spike/openocd.cfg
@@ -8,8 +8,8 @@ set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
 
 set _TARGETNAME $_CHIPNAME.cpu
-#target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos riscv
-target create $_TARGETNAME riscv -chain-position $_TARGETNAME
+target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos riscv
+#target create $_TARGETNAME riscv -chain-position $_TARGETNAME
 
 gdb_report_data_abort enable
 


### PR DESCRIPTION
You'll need my latest OpenOCD for this to actually work.