### PR TITLE
Debug: Usability Features

### DIFF
--- a/debug/targets.py
+++ b/debug/targets.py
@@ -22,6 +22,12 @@ class Target(object):
     # target is defined. Defaults to <name>.cfg.
     openocd_config_path = None
 
+    # Timeout waiting for the server to start up. This is different than the
+    # GDB timeout, which is how long GDB waits for commands to execute.
+    # The server_timeout is how long this script waits for the Server to be ready
+    # for GDB connections.
+    server_timeout_sec = 60
+
     # Path to linker script relative to the .py file where the target is
     # defined. Defaults to <name>.lds.
     link_script_path = None
@@ -72,7 +78,8 @@ class Target(object):
     def server(self):
         """Start the debug server that gdb connects to, eg. OpenOCD."""
         return testlib.Openocd(server_cmd=self.server_cmd,
-                config=self.openocd_config_path)
+                               config=self.openocd_config_path,
+                               timeout=self.server_timeout_sec)
 
     def compile(self, *sources):
         binary_name = "%s_%s-%d" % (

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -561,8 +561,6 @@ class BaseTest(object):
                 result = "fail"
             else:
                 result = "exception"
-                header ("Backtrace")
-                print e
             if isinstance(e, TestFailed):
                 header("Message")
                 print e.message

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -282,7 +282,7 @@ class Gdb(object):
     def __init__(self,
             cmd=os.path.expandvars("$RISCV/bin/riscv64-unknown-elf-gdb")):
         self.child = pexpect.spawn(cmd)
-        self.child.logfile.write("+ %s\n" % cmd)
+        Gdb.logfile.write("+ %s\n" % cmd)
         self.wait()
         self.command("set confirm off")
         self.command("set width 0")

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -161,7 +161,7 @@ class VcsSim(object):
 class Openocd(object):
     logfile = tempfile.NamedTemporaryFile(prefix='openocd', suffix='.log')
     logname = logfile.name
-    print "OpenOCD Temp Logfile: %s " % logname
+    print "OpenOCD Temporary Log File: %s" % logname
 
     def __init__(self, server_cmd=None, config=None, debug=False, timeout=60):
         if server_cmd:
@@ -277,7 +277,7 @@ Thread = collections.namedtuple('Thread', ('id', 'target_id', 'name',
 class Gdb(object):
     logfile = tempfile.NamedTemporaryFile(prefix="gdb", suffix=".log")
     logname = logfile.name
-    print "GDB Temporary file: %s" % logname
+    print "GDB Temporary Log File: %s" % logname
 
     def __init__(self,
             cmd=os.path.expandvars("$RISCV/bin/riscv64-unknown-elf-gdb")):

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -161,8 +161,9 @@ class VcsSim(object):
 class Openocd(object):
     logfile = tempfile.NamedTemporaryFile(prefix='openocd', suffix='.log')
     logname = logfile.name
+    print "OpenOCD Temp Logfile: %s " % logname
 
-    def __init__(self, server_cmd=None, config=None, debug=False):
+    def __init__(self, server_cmd=None, config=None, debug=False, timeout=60):
         if server_cmd:
             cmd = shlex.split(server_cmd)
         else:
@@ -196,7 +197,7 @@ class Openocd(object):
         if debug:
             cmd.append("-d")
 
-        logfile = open(Openocd.logname, "w")
+        logfile = Openocd.logfile
         logfile.write("+ %s\n" % " ".join(cmd))
         logfile.flush()
         self.process = subprocess.Popen(cmd, stdin=subprocess.PIPE,
@@ -223,7 +224,7 @@ class Openocd(object):
                 if not messaged and time.time() - start > 1:
                     messaged = True
                     print "Waiting for OpenOCD to start..."
-                if time.time() - start > 60:
+                if (time.time() - start) > timeout:
                     raise Exception("ERROR: Timed out waiting for OpenOCD to "
                             "listen for gdb")
 
@@ -276,11 +277,11 @@ Thread = collections.namedtuple('Thread', ('id', 'target_id', 'name',
 class Gdb(object):
     logfile = tempfile.NamedTemporaryFile(prefix="gdb", suffix=".log")
     logname = logfile.name
+    print "GDB Temporary file: %s" % logname
 
     def __init__(self,
             cmd=os.path.expandvars("$RISCV/bin/riscv64-unknown-elf-gdb")):
         self.child = pexpect.spawn(cmd)
-        self.child.logfile = open(self.logname, "w")
         self.child.logfile.write("+ %s\n" % cmd)
         self.wait()
         self.command("set confirm off")

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -560,6 +560,8 @@ class BaseTest(object):
                 result = "fail"
             else:
                 result = "exception"
+                header ("Backtrace")
+                print e
             if isinstance(e, TestFailed):
                 header("Message")
                 print e.message


### PR DESCRIPTION
* Print out the path the the temporary OpenOCD/ GDB log files, as for long running simulations it's nice to see what these are doing
* Allow the timeout for OpenOCD startup to be configurable per-target, as simulation targets may take a long time. Addresses #65 