### PR TITLE
Fix rv64mi-csr for the case where U-mode is not available.

### DIFF
--- a/isa/rv64si/csr.S
+++ b/isa/rv64si/csr.S
@@ -26,7 +26,23 @@ RVTEST_CODE_BEGIN
 
   # For RV64, make sure UXL encodes RV64.  (UXL does not exist for RV32.)
 #if __riscv_xlen == 64
+  # If running in M mode, read misa to check existence of U mode.
+  # Otherwise, if in S mode, then U mode must exist and we don't need to check.
+#ifdef __MACHINE_MODE
+  csrr a0, misa
+  srli a0, a0, 'U' - 'A'
+  andi a0, a0, 1
+  beqz a0, 1f
+#endif
+  # If U mode is present, UXL should be 2 (XLEN = 64-bit)
   TEST_CASE(13, a0, SSTATUS_UXL & (SSTATUS_UXL << 1), csrr a0, sstatus; li a1, SSTATUS_UXL; and a0, a0, a1)
+#ifdef __MACHINE_MODE
+  j 2f
+1:
+  # If U mode is not present, UXL should be 0
+  TEST_CASE(14, a0, 0, csrr a0, sstatus; li a1, SSTATUS_UXL; and a0, a0, a1)
+2:
+#endif
 #endif
 
   csrwi sscratch, 3


### PR DESCRIPTION
It looks like the `csr` test incorrectly handles the case where a 64-bit core does not support U mode. Specifically, the UXL test case makes an assertion that is only true for 64-bit cores that support U mode. According to the current version of the Privileged Spec, if a 64-bit core doesn't support U mode, then the UXL register field must be hardwired to 0.

This is my attempt at updating the test to handle this case while not breaking any of the other existing cases. Please let me know if you think there's a cleaner way of fixing the test, since it is admittedly hard to read due to the nested `#if` directives and conditional branches.

To test it, I ran rv64mi-csr on both a 64-bit core with U mode and a 64-bit core without U mode, in addition to running rv64si-csr on a 64-bit core — which must have U mode because the test runs in S mode.