### PR TITLE
Declare trap handlers as global symbols.

### DIFF
--- a/isa/rv64mi/breakpoint.S
+++ b/isa/rv64mi/breakpoint.S
@@ -115,6 +115,8 @@ RVTEST_CODE_BEGIN
 2:
   TEST_PASSFAIL
 
+  .align 2
+  .global mtvec_handler
 mtvec_handler:
   # Only even-numbered tests should trap.
   andi t0, TESTNUM, 1

--- a/isa/rv64mi/illegal.S
+++ b/isa/rv64mi/illegal.S
@@ -106,6 +106,7 @@ bad9:
   TEST_PASSFAIL
 
   .align 8
+  .global mtvec_handler
 mtvec_handler:
   j synchronous_exception
   j msip

--- a/isa/rv64mi/ma_addr.S
+++ b/isa/rv64mi/ma_addr.S
@@ -92,6 +92,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 3
+  .global mtvec_handler
 mtvec_handler:
   csrr t0, mcause
   bne t0, s1, fail

--- a/isa/rv64si/csr.S
+++ b/isa/rv64si/csr.S
@@ -110,6 +110,7 @@ finish:
   TEST_PASSFAIL
 
   .align 2
+  .global stvec_handler
 stvec_handler:
   # Trapping on tests 10-12 is good news.
   # Note that since the test didn't complete, TESTNUM is smaller by 1.

--- a/isa/rv64si/dirty.S
+++ b/isa/rv64si/dirty.S
@@ -74,6 +74,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
+  .global mtvec_handler
 mtvec_handler:
   csrr t0, mcause
   add t0, t0, -CAUSE_STORE_PAGE_FAULT

--- a/isa/rv64si/ma_fetch.S
+++ b/isa/rv64si/ma_fetch.S
@@ -110,6 +110,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
+  .global stvec_handler
 stvec_handler:
   # tests 2, 4, 5, and 6 should trap
   li a0, 2

--- a/isa/rv64si/sbreak.S
+++ b/isa/rv64si/sbreak.S
@@ -30,6 +30,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
+  .global stvec_handler
 stvec_handler:
   li t1, CAUSE_BREAKPOINT
   csrr t0, scause

--- a/isa/rv64si/scall.S
+++ b/isa/rv64si/scall.S
@@ -40,6 +40,7 @@ RVTEST_CODE_BEGIN
   TEST_PASSFAIL
 
   .align 2
+  .global stvec_handler
 stvec_handler:
   li t1, CAUSE_USER_ECALL
   csrr t0, scause


### PR DESCRIPTION
This allows them to be referenced by other files, such as a test environment that lives in a separate compilation unit.