### PR TITLE
Remove cache miss test from last AMO test.

### DIFF
--- a/isa/rv64ua/amoxor_d.S
+++ b/isa/rv64ua/amoxor_d.S
@@ -18,13 +18,6 @@ RVTEST_CODE_BEGIN
     li a1, 0xfffffffffffff800; \
     la a3, amo_operand; \
     sd a0, 0(a3); \
-    nop; nop; nop; nop; \
-    nop; nop; nop; nop; \
-    nop; nop; nop; nop; \
-    nop; nop; nop; nop; \
-    nop; nop; nop; nop; \
-    nop; nop; nop; nop; \
-    nop; nop; nop; nop; \
     amoxor.d	a4, a1, 0(a3); \
   )
 
@@ -33,15 +26,6 @@ RVTEST_CODE_BEGIN
   # try again after a cache miss
   TEST_CASE(4, a4, 0x000000007ffff800, \
     li  a1, 1; \
-    li  a4, 16384; \
-    add a5, a3, a4; \
-    ld  x0, 0(a5); \
-    add a5, a5, a4; \
-    ld  x0, 0(a5); \
-    add a5, a5, a4; \
-    ld  x0, 0(a5); \
-    add a5, a5, a4; \
-    ld  x0, 0(a5); \
     amoxor.d a4, a1, 0(a3); \
   )
 
@@ -62,4 +46,3 @@ RVTEST_DATA_END
   .align 3
 amo_operand:
   .dword 0
-  .skip 65536


### PR DESCRIPTION
Follow-up to b68b39031a730ecc155ed87fba2ed5f111d0ab07.

The 64KiB allocated by the code to force a cache miss makes it impossible to run the test from any memories that are smaller 64KiB, such as scratchpad memories or LIMs. Since this is trying to test microarchitectural behavior, they don't belong in these ISA tests anyway.