### PR TITLE
debug: Need to apply remotetimeout before connecting to remote target

### DIFF
--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -504,8 +504,8 @@ class Gdb(object):
             if m:
                 threads.append(Thread(*m.groups()))
         assert threads
-        # >>>if not threads:
-        # >>>    threads.append(Thread('1', '1', 'Default', '???'))
+        #>>>if not threads:
+        #>>>    threads.append(Thread('1', '1', 'Default', '???'))
         return threads
 
     def thread(self, thread):
@@ -750,9 +750,9 @@ class GdbTest(BaseTest):
         BaseTest.classSetup(self)
 
         if gdb_cmd:
-            self.gdb = Gdb(self.server.gdb_ports, gdb_cmd, timeout = self.target.timeout_sec,  binary=self.binary)
+            self.gdb = Gdb(self.server.gdb_ports, gdb_cmd, timeout=self.target.timeout_sec, binary=self.binary)
         else:
-            self.gdb = Gdb(self.server.gdb_ports, timeout = self.target.timeout_sec, binary=self.binary)
+            self.gdb = Gdb(self.server.gdb_ports, timeout=self.target.timeout_sec, binary=self.binary)
 
         self.logs += self.gdb.lognames()
 

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -314,6 +314,7 @@ class Gdb(object):
 
     def __init__(self, ports,
             cmd=os.path.expandvars("$RISCV/bin/riscv64-unknown-elf-gdb"),
+            timeout=60,
             binary=None):
         assert ports
 
@@ -340,6 +341,7 @@ class Gdb(object):
             self.command("set height 0")
             # Force consistency.
             self.command("set print entry-values no")
+            self.command("set remotetimeout %d" % timeout)
             self.command("target extended-remote localhost:%d" % port)
             if binary:
                 self.command("file %s" % binary)
@@ -502,8 +504,8 @@ class Gdb(object):
             if m:
                 threads.append(Thread(*m.groups()))
         assert threads
-        #>>>if not threads:
-        #>>>    threads.append(Thread('1', '1', 'Default', '???'))
+        # >>>if not threads:
+        # >>>    threads.append(Thread('1', '1', 'Default', '???'))
         return threads
 
     def thread(self, thread):
@@ -748,16 +750,15 @@ class GdbTest(BaseTest):
         BaseTest.classSetup(self)
 
         if gdb_cmd:
-            self.gdb = Gdb(self.server.gdb_ports, gdb_cmd, binary=self.binary)
+            self.gdb = Gdb(self.server.gdb_ports, gdb_cmd, timeout = self.target.timeout_sec,  binary=self.binary)
         else:
-            self.gdb = Gdb(self.server.gdb_ports, binary=self.binary)
+            self.gdb = Gdb(self.server.gdb_ports, timeout = self.target.timeout_sec, binary=self.binary)
 
         self.logs += self.gdb.lognames()
 
-        if self.target:
-            self.gdb.global_command("set arch riscv:rv%d" % self.hart.xlen)
-            self.gdb.global_command("set remotetimeout %d" %
-                    self.target.timeout_sec)
+        self.gdb.global_command("set arch riscv:rv%d" % self.hart.xlen)
+        self.gdb.global_command("set remotetimeout %d" %
+            self.target.timeout_sec)
 
         for cmd in self.target.gdb_setup:
             self.gdb.command(cmd)


### PR DESCRIPTION
Addresses #93 
The `target extended-remote localhost` command itself is a long-running command in need of a timeout, so the `set remotetimeout` command needs to be called before actually connecting to the target, not after.