### PR TITLE
Debug: Use the --32 and --64 command line arguments

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -862,11 +862,7 @@ def main():
     global parsed   # pylint: disable=global-statement
     parsed = parser.parse_args()
     target = targets.target(parsed)
-
     testlib.print_log_names = parsed.print_log_names
-
-    if parsed.xlen:
-        target.xlen = parsed.xlen
 
     module = sys.modules[__name__]
 

--- a/debug/targets.py
+++ b/debug/targets.py
@@ -180,5 +180,10 @@ def target(parsed):
 
     t = found[0](parsed.target, parsed)
     assert t.harts, "%s doesn't have any harts defined!" % t.name
+    for h in t.harts :
+        if (h.xlen == 0):
+            h.xlen = parsed.xlen
+        elif (h.xlen != parsed.xlen):
+            raise Exception("Hart had a specified XLEN of %d and target had a specified XLEN of %d, they must match." % (h.xlen, parsed.xlen))
 
     return t

--- a/debug/targets.py
+++ b/debug/targets.py
@@ -184,6 +184,6 @@ def target(parsed):
         if (h.xlen == 0):
             h.xlen = parsed.xlen
         elif (h.xlen != parsed.xlen):
-            raise Exception("Hart had a specified XLEN of %d and target had a specified XLEN of %d, they must match." % (h.xlen, parsed.xlen))
+            raise Exception("The target has an XLEN of %d, but the command line specified an XLEN of %d. They must match." % (h.xlen, parsed.xlen))
 
     return t

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -825,15 +825,21 @@ class ExamineTarget(GdbTest):
             hart.misa = self.gdb.p("$misa")
 
             txt = "RV"
-            if (hart.misa >> 30) == 1:
-                txt += "32"
-            elif (hart.misa >> 62) == 2:
-                txt += "64"
-            elif (hart.misa >> 126) == 3:
-                txt += "128"
+            misa_xlen = 0
+            if ((hart.misa & 0xFFFFFFFF) >> 30) == 1:
+                misa_xlen = 32
+            elif ((hart.misa & 0xFFFFFFFFFFFFFFFF) >> 62) == 2:
+                misa_xlen = 64
+            elif ((hart.misa & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) >> 126) == 3:
+                misa_xlen = 128
             else:
                 raise TestFailed("Couldn't determine XLEN from $misa (0x%x)" %
                         self.hart.misa)
+
+            if (misa_xlen != hart.xlen):
+                raise TestFailed("MISA reported XLEN of %d but we were expecting XLEN of %d\n" % (misa_xlen, hart.xlen))
+
+            txt += ("%d" % misa_xlen)
 
             for i in range(26):
                 if hart.misa & (1<<i):


### PR DESCRIPTION
This is to address #96, but I'm not sure this is the change that makes sense.