### PR TITLE
Rv32ud tests

### DIFF
--- a/isa/Makefile
+++ b/isa/Makefile
@@ -19,6 +19,7 @@ include $(src_dir)/rv32uc/Makefrag
 include $(src_dir)/rv32um/Makefrag
 include $(src_dir)/rv32ua/Makefrag
 include $(src_dir)/rv32uf/Makefrag
+include $(src_dir)/rv32ud/Makefrag
 include $(src_dir)/rv32si/Makefrag
 include $(src_dir)/rv32mi/Makefrag
 
@@ -73,6 +74,7 @@ $(eval $(call compile_template,rv32uc,-march=rv32g -mabi=ilp32))
 $(eval $(call compile_template,rv32um,-march=rv32g -mabi=ilp32))
 $(eval $(call compile_template,rv32ua,-march=rv32g -mabi=ilp32))
 $(eval $(call compile_template,rv32uf,-march=rv32g -mabi=ilp32))
+$(eval $(call compile_template,rv32ud,-march=rv32g -mabi=ilp32))
 $(eval $(call compile_template,rv32si,-march=rv32g -mabi=ilp32))
 $(eval $(call compile_template,rv32mi,-march=rv32g -mabi=ilp32))
 ifeq ($(XLEN),64)

--- a/isa/Makefile
+++ b/isa/Makefile
@@ -6,6 +6,7 @@ XLEN ?= 64
 
 src_dir := .
 
+ifeq ($(XLEN),64)
 include $(src_dir)/rv64ui/Makefrag
 include $(src_dir)/rv64uc/Makefrag
 include $(src_dir)/rv64um/Makefrag
@@ -14,6 +15,7 @@ include $(src_dir)/rv64uf/Makefrag
 include $(src_dir)/rv64ud/Makefrag
 include $(src_dir)/rv64si/Makefrag
 include $(src_dir)/rv64mi/Makefrag
+endif
 include $(src_dir)/rv32ui/Makefrag
 include $(src_dir)/rv32uc/Makefrag
 include $(src_dir)/rv32um/Makefrag

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -423,6 +423,31 @@ test_ ## testnum: \
   .result; \
   .popsection
 
+#define TEST_FP_OP_D32_INTERNAL( testnum, flags, result, val1, val2, val3, code... ) \
+test_ ## testnum: \
+  li  TESTNUM, testnum; \
+  la  a0, test_ ## testnum ## _data ;\
+  fld f0, 0(a0); \
+  fld f1, 8(a0); \
+  fld f2, 16(a0); \
+  lw  a3, 24(a0); \
+  lw  t1, 28(a0); \
+  code; \
+  fsflags a1, x0; \
+  li a2, flags; \
+  bne a0, a3, fail; \
+  bne t1, t2, fail; \
+  bne a1, a2, fail; \
+  .pushsection .data; \
+  .align 3; \
+  test_ ## testnum ## _data: \
+  .double val1; \
+  .double val2; \
+  .double val3; \
+  .result; \
+  .popsection
+
+// TODO: make 32-bit variant
 #define TEST_FCVT_S_D( testnum, result, val1 ) \
   TEST_FP_OP_D_INTERNAL( testnum, 0, double result, val1, 0.0, 0.0, \
                     fcvt.s.d f3, f0; fcvt.d.s f3, f3; fmv.x.d a0, f3)
@@ -435,6 +460,7 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, 0.0, 0.0, \
                     inst f3, f0; fmv.x.s a0, f3)
 
+// TODO: make 32-bit variant
 #define TEST_FP_OP1_D( testnum, inst, flags, result, val1 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, 0.0, 0.0, \
                     inst f3, f0; fmv.x.d a0, f3)
@@ -443,6 +469,7 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
                     inst f3, f0; fmv.x.s a0, f3)
 
+// TODO: make 32-bit variant
 #define TEST_FP_OP1_D_DWORD_RESULT( testnum, inst, flags, result, val1 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
                     inst f3, f0; fmv.x.d a0, f3)
@@ -450,6 +477,11 @@ test_ ## testnum: \
 #define TEST_FP_OP2_S( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, val2, 0.0, \
                     inst f3, f0, f1; fmv.x.s a0, f3)
+
+#define TEST_FP_OP2_D32( testnum, inst, flags, result, val1, val2 ) \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, val1, val2, 0.0, \
+                    inst f3, f0, f1; fsd f3, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
+// ^: store computation result in address from a0, load high-word into t2
 
 #define TEST_FP_OP2_D( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, val2, 0.0, \
@@ -459,6 +491,7 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, val2, val3, \
                     inst f3, f0, f1, f2; fmv.x.s a0, f3)
 
+// TODO: make 32-bit variant
 #define TEST_FP_OP3_D( testnum, inst, flags, result, val1, val2, val3 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, val2, val3, \
                     inst f3, f0, f1, f2; fmv.x.d a0, f3)
@@ -467,6 +500,7 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, word result, val1, 0.0, 0.0, \
                     inst a0, f0, rm)
 
+// TODO: make 32-bit variant
 #define TEST_FP_INT_OP_D( testnum, inst, flags, result, val1, rm ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
                     inst a0, f0, rm)
@@ -475,6 +509,7 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, word result, val1, val2, 0.0, \
                     inst a0, f0, f1)
 
+// TODO: make 32-bit variant
 #define TEST_FP_CMP_OP_D( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, val1, val2, 0.0, \
                     inst a0, f0, f1)
@@ -483,6 +518,7 @@ test_ ## testnum: \
   TEST_CASE(testnum, a0, correct, li a0, input; fmv.s.x fa0, a0; \
                     fclass.s a0, fa0)
 
+// TODO: make 32-bit variant
 #define TEST_FCLASS_D(testnum, correct, input) \
   TEST_CASE(testnum, a0, correct, li a0, input; fmv.d.x fa0, a0; \
                     fclass.d a0, fa0)
@@ -503,6 +539,7 @@ test_ ## testnum: \
   .float result; \
   .popsection
 
+// TODO: make 32-bit variant
 #define TEST_INT_FP_OP_D( testnum, inst, result, val1 ) \
 test_ ## testnum: \
   li  TESTNUM, testnum; \

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -423,7 +423,7 @@ test_ ## testnum: \
   .result; \
   .popsection
 
-// TODO: assign a separate mem location for the comparison address
+// TODO: assign a separate mem location for the comparison address?
 #define TEST_FP_OP_D32_INTERNAL( testnum, flags, result, val1, val2, val3, code... ) \
 test_ ## testnum: \
   li  TESTNUM, testnum; \
@@ -448,7 +448,10 @@ test_ ## testnum: \
   .result; \
   .popsection
 
-// TODO: make 32-bit variant
+#define TEST_FCVT_S_D32( testnum, result, val1 ) \
+  TEST_FP_OP_D32_INTERNAL( testnum, 0, double result, val1, 0.0, 0.0, \
+                    fcvt.s.d f3, f0; fcvt.d.s f3, f3; fsd f3, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
+
 #define TEST_FCVT_S_D( testnum, result, val1 ) \
   TEST_FP_OP_D_INTERNAL( testnum, 0, double result, val1, 0.0, 0.0, \
                     fcvt.s.d f3, f0; fcvt.d.s f3, f3; fmv.x.d a0, f3)
@@ -513,7 +516,10 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, word result, val1, 0.0, 0.0, \
                     inst a0, f0, rm)
 
-// TODO: make 32-bit variant
+#define TEST_FP_INT_OP_D32( testnum, inst, flags, result, val1, rm ) \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
+                    inst a0, f0, f1; li t2, 0)
+
 #define TEST_FP_INT_OP_D( testnum, inst, flags, result, val1, rm ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
                     inst a0, f0, rm)
@@ -565,7 +571,28 @@ test_ ## testnum: \
   .float result; \
   .popsection
 
-// TODO: make 32-bit variant
+#define TEST_INT_FP_OP_D32( testnum, inst, result, val1 ) \
+test_ ## testnum: \
+  li  TESTNUM, testnum; \
+  la  a0, test_ ## testnum ## _data ;\
+  lw  a3, 0(a0); \
+  lw  a4, 4(a0); \
+  li  a1, val1; \
+  inst f0, a1; \
+  \
+  fsd f0, 0(a0); \
+  lw a1, 4(a0); \
+  lw a0, 0(a0); \
+  \
+  fsflags x0; \
+  bne a0, a3, fail; \
+  bne a1, a4, fail; \
+  .pushsection .data; \
+  .align 3; \
+  test_ ## testnum ## _data: \
+  .double result; \
+  .popsection
+
 #define TEST_INT_FP_OP_D( testnum, inst, result, val1 ) \
 test_ ## testnum: \
   li  TESTNUM, testnum; \

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -423,6 +423,7 @@ test_ ## testnum: \
   .result; \
   .popsection
 
+// TODO: assign a separate mem location for the comparison address
 #define TEST_FP_OP_D32_INTERNAL( testnum, flags, result, val1, val2, val3, code... ) \
 test_ ## testnum: \
   li  TESTNUM, testnum; \
@@ -555,6 +556,25 @@ test_ ## testnum: \
   test_ ## testnum ## _data: \
   .double result; \
   .popsection
+
+// We need some special handling here to allow 64-bit comparison in 32-bit arch
+// TODO: find a better name and clean up when intended for general usage?
+#define TEST_LDST_D32( testnum, testreg1, testreg2, correctval, code... ) \
+test_ ## testnum: \
+    code; \
+    la  x31, test_ ## testnum ## _data ; \
+    lw  x29, 0(x31); \
+    lw  x31, 4(x31); \
+    li  TESTNUM, testnum; \
+    bne testreg1, x29, fail;\
+    bne testreg2, x31, fail;\
+    .pushsection .data; \
+    .align 3; \
+    test_ ## testnum ## _data: \
+    .dword correctval; \
+    .popsection
+
+// ^ x30 is used in some other macros, to avoid issues we use x31 for upper word
 
 #-----------------------------------------------------------------------
 # Pass and fail code (assumes test num is in TESTNUM)

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -522,7 +522,10 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, word result, val1, val2, 0.0, \
                     inst a0, f0, f1)
 
-// TODO: make 32-bit variant
+#define TEST_FP_CMP_OP_D32( testnum, inst, flags, result, val1, val2 ) \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, val1, val2, 0.0, \
+                    inst a0, f0, f1; li t2, 0)
+
 #define TEST_FP_CMP_OP_D( testnum, inst, flags, result, val1, val2 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, val1, val2, 0.0, \
                     inst a0, f0, f1)

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -519,7 +519,17 @@ test_ ## testnum: \
   TEST_CASE(testnum, a0, correct, li a0, input; fmv.s.x fa0, a0; \
                     fclass.s a0, fa0)
 
-// TODO: make 32-bit variant
+#define TEST_FCLASS_D32(testnum, correct, input) \
+  TEST_CASE(testnum, a0, correct, \
+            la a0, test_ ## testnum ## _data ;\
+            fld fa0, 0(a0); \
+            fclass.d a0, fa0) \
+    .pushsection .data; \
+    .align 3; \
+    test_ ## testnum ## _data: \
+    .dword input; \
+    .popsection
+
 #define TEST_FCLASS_D(testnum, correct, input) \
   TEST_CASE(testnum, a0, correct, li a0, input; fmv.d.x fa0, a0; \
                     fclass.d a0, fa0)

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -500,7 +500,11 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, val2, val3, \
                     inst f3, f0, f1, f2; fmv.x.s a0, f3)
 
-// TODO: make 32-bit variant
+#define TEST_FP_OP3_D32( testnum, inst, flags, result, val1, val2, val3 ) \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, val1, val2, val3, \
+                    inst f3, f0, f1, f2; fsd f3, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
+// ^: store computation result in address from a0, load high-word into t2
+
 #define TEST_FP_OP3_D( testnum, inst, flags, result, val1, val2, val3 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, val2, val3, \
                     inst f3, f0, f1, f2; fmv.x.d a0, f3)

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -611,7 +611,7 @@ test_ ## testnum: \
 
 // We need some special handling here to allow 64-bit comparison in 32-bit arch
 // TODO: find a better name and clean up when intended for general usage?
-#define TEST_LDST_D32( testnum, testreg1, testreg2, correctval, code... ) \
+#define TEST_CASE_D32( testnum, testreg1, testreg2, correctval, code... ) \
 test_ ## testnum: \
     code; \
     la  x31, test_ ## testnum ## _data ; \

--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -461,7 +461,11 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, float result, val1, 0.0, 0.0, \
                     inst f3, f0; fmv.x.s a0, f3)
 
-// TODO: make 32-bit variant
+#define TEST_FP_OP1_D32( testnum, inst, flags, result, val1 ) \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, double result, val1, 0.0, 0.0, \
+                    inst f3, f0; fsd f3, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
+// ^: store computation result in address from a0, load high-word into t2
+
 #define TEST_FP_OP1_D( testnum, inst, flags, result, val1 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, double result, val1, 0.0, 0.0, \
                     inst f3, f0; fmv.x.d a0, f3)
@@ -470,7 +474,11 @@ test_ ## testnum: \
   TEST_FP_OP_S_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
                     inst f3, f0; fmv.x.s a0, f3)
 
-// TODO: make 32-bit variant
+#define TEST_FP_OP1_D32_DWORD_RESULT( testnum, inst, flags, result, val1 ) \
+  TEST_FP_OP_D32_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
+                    inst f3, f0; fsd f3, 0(a0); lw t2, 4(a0); lw a0, 0(a0))
+// ^: store computation result in address from a0, load high-word into t2
+
 #define TEST_FP_OP1_D_DWORD_RESULT( testnum, inst, flags, result, val1 ) \
   TEST_FP_OP_D_INTERNAL( testnum, flags, dword result, val1, 0.0, 0.0, \
                     inst f3, f0; fmv.x.d a0, f3)

--- a/isa/rv32ud/Makefrag
+++ b/isa/rv32ud/Makefrag
@@ -1,0 +1,15 @@
+#=======================================================================
+# Makefrag for rv32ud tests
+#-----------------------------------------------------------------------
+
+rv32ud_sc_tests = \
+	fadd fdiv fclass fcmp fcvt fcvt_w fmadd fmin \
+	ldst recoding \
+
+# TODO: use this line instead of the last of the previous once move and structural tests have been implemented
+#        ldst move structural recoding \
+
+rv32ud_p_tests = $(addprefix rv32ud-p-, $(rv32ud_sc_tests))
+rv32ud_v_tests = $(addprefix rv32ud-v-, $(rv32ud_sc_tests))
+
+spike32_tests += $(rv32ud_p_tests) $(rv32ud_v_tests)

--- a/isa/rv32ud/fadd.S
+++ b/isa/rv32ud/fadd.S
@@ -1,0 +1,7 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64UF
+#define RVTEST_RV64UF RVTEST_RV32UF
+
+#include "../rv64ud/fadd.S"

--- a/isa/rv32ud/fclass.S
+++ b/isa/rv32ud/fclass.S
@@ -1,0 +1,7 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64UF
+#define RVTEST_RV64UF RVTEST_RV32UF
+
+#include "../rv64ud/fclass.S"

--- a/isa/rv32ud/fcmp.S
+++ b/isa/rv32ud/fcmp.S
@@ -1,0 +1,7 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64UF
+#define RVTEST_RV64UF RVTEST_RV32UF
+
+#include "../rv64ud/fcmp.S"

--- a/isa/rv32ud/fcvt.S
+++ b/isa/rv32ud/fcvt.S
@@ -1,0 +1,7 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64UF
+#define RVTEST_RV64UF RVTEST_RV32UF
+
+#include "../rv64ud/fcvt.S"

--- a/isa/rv32ud/fcvt_w.S
+++ b/isa/rv32ud/fcvt_w.S
@@ -1,0 +1,7 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64UF
+#define RVTEST_RV64UF RVTEST_RV32UF
+
+#include "../rv64uf/fcvt_w.S"

--- a/isa/rv32ud/fdiv.S
+++ b/isa/rv32ud/fdiv.S
@@ -1,0 +1,7 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64UF
+#define RVTEST_RV64UF RVTEST_RV32UF
+
+#include "../rv64ud/fdiv.S"

--- a/isa/rv32ud/fmadd.S
+++ b/isa/rv32ud/fmadd.S
@@ -1,0 +1,7 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64UF
+#define RVTEST_RV64UF RVTEST_RV32UF
+
+#include "../rv64ud/fmadd.S"

--- a/isa/rv32ud/fmin.S
+++ b/isa/rv32ud/fmin.S
@@ -1,0 +1,7 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64UF
+#define RVTEST_RV64UF RVTEST_RV32UF
+
+#include "../rv64ud/fmin.S"

--- a/isa/rv32ud/ldst.S
+++ b/isa/rv32ud/ldst.S
@@ -14,11 +14,11 @@ RVTEST_RV32UF
 RVTEST_CODE_BEGIN
 
   la s0, tdat
-  TEST_LDST_D32(2, a0, a1, 0x40000000bf800000, fld f2, 0(s0); fsd f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
-  TEST_LDST_D32(3, a0, a1, 0x40000000bf800000, fld f2, 0(s0); fsw f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
-  TEST_LDST_D32(4, a0, a1, 0x40000000bf800000, flw f2, 0(s0); fsw f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
-  TEST_LDST_D32(5, a0, a1, 0xc080000040400000, fld f2, 8(s0); fsd f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
-  TEST_LDST_D32(6, a0, a1, 0xffffffff40400000, flw f2, 8(s0); fsd f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
+  TEST_CASE_D32(2, a0, a1, 0x40000000bf800000, fld f2, 0(s0); fsd f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
+  TEST_CASE_D32(3, a0, a1, 0x40000000bf800000, fld f2, 0(s0); fsw f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
+  TEST_CASE_D32(4, a0, a1, 0x40000000bf800000, flw f2, 0(s0); fsw f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
+  TEST_CASE_D32(5, a0, a1, 0xc080000040400000, fld f2, 8(s0); fsd f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
+  TEST_CASE_D32(6, a0, a1, 0xffffffff40400000, flw f2, 8(s0); fsd f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
 
   TEST_PASSFAIL
 

--- a/isa/rv32ud/ldst.S
+++ b/isa/rv32ud/ldst.S
@@ -1,0 +1,42 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# ldst.S
+#-----------------------------------------------------------------------------
+#
+# This test verifies that flw, fld, fsw, and fsd work properly.
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32UF
+RVTEST_CODE_BEGIN
+
+  la s0, tdat
+  TEST_LDST_D32(2, a0, a1, 0x40000000bf800000, fld f2, 0(s0); fsd f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
+  TEST_LDST_D32(3, a0, a1, 0x40000000bf800000, fld f2, 0(s0); fsw f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
+  TEST_LDST_D32(4, a0, a1, 0x40000000bf800000, flw f2, 0(s0); fsw f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
+  TEST_LDST_D32(5, a0, a1, 0xc080000040400000, fld f2, 8(s0); fsd f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
+  TEST_LDST_D32(6, a0, a1, 0xffffffff40400000, flw f2, 8(s0); fsd f2, 16(s0); lw a0, 16(s0); lw a1, 20(s0))
+
+  TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+tdat:
+.word 0xbf800000
+.word 0x40000000
+.word 0x40400000
+.word 0xc0800000
+.word 0xdeadbeef
+.word 0xcafebabe
+.word 0xabad1dea
+.word 0x1337d00d
+
+RVTEST_DATA_END

--- a/isa/rv32ud/move.S
+++ b/isa/rv32ud/move.S
@@ -1,0 +1,7 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64UF
+#define RVTEST_RV64UF RVTEST_RV32UF
+
+#include "../rv64ud/move.S"

--- a/isa/rv32ud/recoding.S
+++ b/isa/rv32ud/recoding.S
@@ -1,0 +1,7 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64UF
+#define RVTEST_RV64UF RVTEST_RV32UF
+
+#include "../rv64uf/recoding.S"

--- a/isa/rv64ud/fadd.S
+++ b/isa/rv64ud/fadd.S
@@ -13,6 +13,12 @@
 RVTEST_RV64UF
 RVTEST_CODE_BEGIN
 
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_FP_OP2_D
+    #define TEST_FP_OP2_D TEST_FP_OP2_D32
+#endif
+
   #-------------------------------------------------------------
   # Arithmetic tests
   #-------------------------------------------------------------

--- a/isa/rv64ud/fclass.S
+++ b/isa/rv64ud/fclass.S
@@ -13,6 +13,12 @@
 RVTEST_RV64UF
 RVTEST_CODE_BEGIN
 
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_FCLASS_D
+    #define TEST_FCLASS_D TEST_FCLASS_D32
+#endif
+
   #-------------------------------------------------------------
   # Arithmetic tests
   #-------------------------------------------------------------

--- a/isa/rv64ud/fcmp.S
+++ b/isa/rv64ud/fcmp.S
@@ -17,6 +17,12 @@ RVTEST_CODE_BEGIN
   # Arithmetic tests
   #-------------------------------------------------------------
 
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_FP_CMP_OP_D
+    #define TEST_FP_CMP_OP_D TEST_FP_CMP_OP_D32
+#endif
+
   TEST_FP_CMP_OP_D( 2, feq.d, 0x00, 1, -1.36, -1.36)
   TEST_FP_CMP_OP_D( 3, fle.d, 0x00, 1, -1.36, -1.36)
   TEST_FP_CMP_OP_D( 4, flt.d, 0x00, 0, -1.36, -1.36)

--- a/isa/rv64ud/fcvt.S
+++ b/isa/rv64ud/fcvt.S
@@ -53,7 +53,15 @@ RVTEST_CODE_BEGIN
     fmv.x.d a0, f2;
   )
 #else
-    # TODO: make 32-bit friendly version
+  TEST_CASE_D32(12, a0, a1, 0x7ff8000000000000,
+    la a1, test_data_22;
+    fld f2, 0(a1);
+    fcvt.s.d f2, f2;
+    fcvt.d.s f2, f2;
+    fsd f2, 0(a1);
+    lw a0, 0(a1);
+    lw a1, 4(a1)
+  )
 #endif
 
   TEST_PASSFAIL

--- a/isa/rv64ud/fcvt.S
+++ b/isa/rv64ud/fcvt.S
@@ -23,15 +23,18 @@ RVTEST_CODE_BEGIN
   TEST_INT_FP_OP_D(4, fcvt.d.wu,                   2.0,  2);
   TEST_INT_FP_OP_D(5, fcvt.d.wu,            4294967294, -2);
 
+#if __riscv_xlen >= 64
   TEST_INT_FP_OP_D(6,  fcvt.d.l,                   2.0,  2);
   TEST_INT_FP_OP_D(7,  fcvt.d.l,                  -2.0, -2);
 
   TEST_INT_FP_OP_D(8, fcvt.d.lu,                   2.0,  2);
   TEST_INT_FP_OP_D(9, fcvt.d.lu, 1.8446744073709552e19, -2);
+#endif
 
   TEST_FCVT_S_D(10, -1.5, -1.5)
   TEST_FCVT_D_S(11, -1.5, -1.5)
 
+# TODO: make 32-bit friendly version
   TEST_CASE(12, a0, 0x7ff8000000000000,
     la a1, test_data_22;
     ld a2, 0(a1);

--- a/isa/rv64ud/fcvt.S
+++ b/isa/rv64ud/fcvt.S
@@ -13,6 +13,15 @@
 RVTEST_RV64UF
 RVTEST_CODE_BEGIN
 
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_INT_FP_OP_D
+    #define TEST_INT_FP_OP_D TEST_INT_FP_OP_D32
+
+    #undef TEST_FCVT_S_D
+    #define TEST_FCVT_S_D TEST_FCVT_S_D32
+#endif
+
   #-------------------------------------------------------------
   # Arithmetic tests
   #-------------------------------------------------------------
@@ -34,7 +43,7 @@ RVTEST_CODE_BEGIN
   TEST_FCVT_S_D(10, -1.5, -1.5)
   TEST_FCVT_D_S(11, -1.5, -1.5)
 
-# TODO: make 32-bit friendly version
+#if __riscv_xlen >= 64
   TEST_CASE(12, a0, 0x7ff8000000000000,
     la a1, test_data_22;
     ld a2, 0(a1);
@@ -43,6 +52,9 @@ RVTEST_CODE_BEGIN
     fcvt.d.s f2, f2;
     fmv.x.d a0, f2;
   )
+#else
+    # TODO: make 32-bit friendly version
+#endif
 
   TEST_PASSFAIL
 

--- a/isa/rv64ud/fcvt_w.S
+++ b/isa/rv64ud/fcvt_w.S
@@ -35,6 +35,7 @@ RVTEST_CODE_BEGIN
   TEST_FP_INT_OP_D(18, fcvt.wu.d, 0x10,          0, -3e9, rtz);
   TEST_FP_INT_OP_D(19, fcvt.wu.d, 0x00, 0xffffffffb2d05e00, 3e9, rtz);
 
+#if __riscv_xlen >= 64
   TEST_FP_INT_OP_D(22,  fcvt.l.d, 0x01,         -1, -1.1, rtz);
   TEST_FP_INT_OP_D(23,  fcvt.l.d, 0x00,         -1, -1.0, rtz);
   TEST_FP_INT_OP_D(24,  fcvt.l.d, 0x01,          0, -0.9, rtz);
@@ -54,28 +55,39 @@ RVTEST_CODE_BEGIN
   TEST_FP_INT_OP_D(37, fcvt.lu.d, 0x01,          1,  1.1, rtz);
   TEST_FP_INT_OP_D(38, fcvt.lu.d, 0x10,          0, -3e9, rtz);
   TEST_FP_INT_OP_D(39, fcvt.lu.d, 0x00, 3000000000,  3e9, rtz);
+#endif
 
   # test negative NaN, negative infinity conversion
   TEST_CASE(42, x1, 0x000000007fffffff, la x1, tdat_d; fld f1,  0(x1); fcvt.w.d x1, f1)
+#if __riscv_xlen >= 64
   TEST_CASE(43, x1, 0x7fffffffffffffff, la x1, tdat_d; fld f1,  0(x1); fcvt.l.d x1, f1)
+#endif
   TEST_CASE(44, x1, 0xffffffff80000000, la x1, tdat_d; fld f1, 16(x1); fcvt.w.d x1, f1)
+#if __riscv_xlen >= 64
   TEST_CASE(45, x1, 0x8000000000000000, la x1, tdat_d; fld f1, 16(x1); fcvt.l.d x1, f1)
+#endif
 
   # test positive NaN, positive infinity conversion
   TEST_CASE(52, x1, 0x000000007fffffff, la x1, tdat_d; fld f1,  8(x1); fcvt.w.d x1, f1)
+#if __riscv_xlen >= 64
   TEST_CASE(53, x1, 0x7fffffffffffffff, la x1, tdat_d; fld f1,  8(x1); fcvt.l.d x1, f1)
+#endif
   TEST_CASE(54, x1, 0x000000007fffffff, la x1, tdat_d; fld f1, 24(x1); fcvt.w.d x1, f1)
+#if __riscv_xlen >= 64
   TEST_CASE(55, x1, 0x7fffffffffffffff, la x1, tdat_d; fld f1, 24(x1); fcvt.l.d x1, f1)
+#endif
 
   # test NaN, infinity conversions to unsigned integer
   TEST_CASE(62, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1,  0(x1); fcvt.wu.d x1, f1)
   TEST_CASE(63, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1,  8(x1); fcvt.wu.d x1, f1)
   TEST_CASE(64, x1,                  0, la x1, tdat_d; fld f1, 16(x1); fcvt.wu.d x1, f1)
   TEST_CASE(65, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1, 24(x1); fcvt.wu.d x1, f1)
+#if __riscv_xlen >= 64
   TEST_CASE(66, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1,  0(x1); fcvt.lu.d x1, f1)
   TEST_CASE(67, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1,  8(x1); fcvt.lu.d x1, f1)
   TEST_CASE(68, x1,                  0, la x1, tdat_d; fld f1, 16(x1); fcvt.lu.d x1, f1)
   TEST_CASE(69, x1, 0xffffffffffffffff, la x1, tdat_d; fld f1, 24(x1); fcvt.lu.d x1, f1)
+#endif
 
   TEST_PASSFAIL
 

--- a/isa/rv64ud/fdiv.S
+++ b/isa/rv64ud/fdiv.S
@@ -14,9 +14,15 @@ RVTEST_RV64UF
 RVTEST_CODE_BEGIN
 
 #if __riscv_xlen == 32
-    # Replace the function with the 32-bit variant defined in test_macros.h
+    # Replace the functions with the 32-bit variants defined in test_macros.h
     #undef TEST_FP_OP2_D
     #define TEST_FP_OP2_D TEST_FP_OP2_D32
+
+    #undef TEST_FP_OP1_D
+    #define TEST_FP_OP1_D TEST_FP_OP1_D32
+
+    #undef TEST_FP_OP1_D_DWORD_RESULT
+    #define TEST_FP_OP1_D_DWORD_RESULT TEST_FP_OP1_D32_DWORD_RESULT
 #endif
 
   #-------------------------------------------------------------

--- a/isa/rv64ud/fdiv.S
+++ b/isa/rv64ud/fdiv.S
@@ -13,6 +13,12 @@
 RVTEST_RV64UF
 RVTEST_CODE_BEGIN
 
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_FP_OP2_D
+    #define TEST_FP_OP2_D TEST_FP_OP2_D32
+#endif
+
   #-------------------------------------------------------------
   # Arithmetic tests
   #-------------------------------------------------------------

--- a/isa/rv64ud/fmadd.S
+++ b/isa/rv64ud/fmadd.S
@@ -13,6 +13,12 @@
 RVTEST_RV64UF
 RVTEST_CODE_BEGIN
 
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_FP_OP3_D
+    #define TEST_FP_OP3_D TEST_FP_OP3_D32
+#endif
+
   #-------------------------------------------------------------
   # Arithmetic tests
   #-------------------------------------------------------------

--- a/isa/rv64ud/fmin.S
+++ b/isa/rv64ud/fmin.S
@@ -13,6 +13,12 @@
 RVTEST_RV64UF
 RVTEST_CODE_BEGIN
 
+#if __riscv_xlen == 32
+    # Replace the function with the 32-bit variant defined in test_macros.h
+    #undef TEST_FP_OP2_D
+    #define TEST_FP_OP2_D TEST_FP_OP2_D32
+#endif
+
   #-------------------------------------------------------------
   # Arithmetic tests
   #-------------------------------------------------------------

--- a/isa/rv64ud/move.S
+++ b/isa/rv64ud/move.S
@@ -13,6 +13,7 @@
 RVTEST_RV64UF
 RVTEST_CODE_BEGIN
 
+#TODO: make 32-bit compatible version
 #define TEST_FSGNJD(n, insn, new_sign, rs1_sign, rs2_sign) \
   TEST_CASE(n, a0, 0x123456789abcdef0 | (-(new_sign) << 63), \
     li a1, ((rs1_sign) << 63) | 0x123456789abcdef0; \


### PR DESCRIPTION
This fork adds ISA verification tests for the `rv32ud` extension, as discussed in issue #85.

The `move` and `structural` tests are yet to be ported, but it should not be too much work left, and the tests that already work may come in handy to others.