### PR TITLE
Compute gdb command timeout based on ops estimate

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -835,7 +835,7 @@ class DownloadTest(GdbTest):
     def test(self):
         self.gdb.load()
         self.gdb.command("b _exit")
-        self.gdb.c(timeout=60)
+        self.gdb.c()
         assertEqual(self.gdb.p("status"), self.crc)
         os.unlink(self.download_c.name)
 


### PR DESCRIPTION
The caller of gdb.command() should estimate how much work gdb needs to
do, and testlib then scales this up proportional to the general gdb
timeout we configured. This hopefully allows us to configure a tighter
timeout, so we don't have to have a multi-hour timeout just for
something that takes long like `load` on a really slow simulator.

Hopefully this addresses #122.

This passed a rocket-chip build in https://github.com/freechipsproject/rocket-chip/pull/1327