### PR TITLE
debug: need to clear satp before changing priv

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -881,6 +881,13 @@ class PrivRw(PrivTest):
             # PMP registers are optional
             pass
 
+        # Ensure Virtual Memory is disabled if applicable (SATP register is not reset)
+        try:
+           self.gdb.p("$satp=0")
+        except testlib.CouldNotFetch:
+           # SATP only exists if you have S mode.
+           pass
+        
         # Leave the PC at _start, where the first 4 instructions should be
         # legal in any mode.
         for privilege in range(4):


### PR DESCRIPTION
ISA Manual does not require this register to be reset, and attempting to execute code with VM enabled when VM hasn't been set up is going to just lead to sadness 50% of the time.