### PR TITLE
[rv64ua/lrsc] Initialize memory read out.

### DIFF
--- a/isa/rv64ua/lrsc.S
+++ b/isa/rv64ua/lrsc.S
@@ -35,7 +35,7 @@ TEST_CASE( 2, a4, 1, \
 # TODO is this actually mandatory behavior?
 TEST_CASE( 3, a4, 1, \
   la a0, foo; \
-  add a1, a0, 1024; \
+  la a1, fooTest3; \
   lr.w a1, (a1); \
   sc.w a4, a1, (a0); \
 )
@@ -82,4 +82,6 @@ RVTEST_DATA_BEGIN
 coreid: .word 0
 barrier: .word 0
 foo: .word 0
+.align 10
+fooTest3: .word 0
 RVTEST_DATA_END

--- a/isa/rv64ua/lrsc.S
+++ b/isa/rv64ua/lrsc.S
@@ -82,6 +82,6 @@ RVTEST_DATA_BEGIN
 coreid: .word 0
 barrier: .word 0
 foo: .word 0
-.align 10
+.skip 1024
 fooTest3: .word 0
 RVTEST_DATA_END


### PR DESCRIPTION
Even though the load contents are discarded, this un-initialized memory value
can lead to a divergence for co-simulation between two different RISC-V designs.

Closes #134.