### PR TITLE
Mark more Debug tests as "Single Hart"

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -351,9 +351,7 @@ class DebugSymbols(DebugTest):
 
 class DebugBreakpoint(DebugTest):
     def test(self):
-
         self.gdb.b("rot13")
-
         # The breakpoint should be hit exactly 2 times.
         for _ in range(2):
             output = self.gdb.c()

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -549,6 +549,8 @@ class Gdb(object):
         output = self.command("load", ops=1000)
         assert "failed" not in  output
         assert "Transfer rate" in output
+        output = self.command("compare-sections", ops=1000)
+        assert "MIS" not in output
 
     def b(self, location):
         output = self.command("b %s" % location, ops=5)
@@ -852,6 +854,8 @@ class GdbTest(BaseTest):
         self.gdb.interrupt()
         self.gdb.command("disassemble", ops=20)
         self.gdb.command("info registers all", ops=100)
+        self.gdb.command("flush regs")
+        self.gdb.command("info threads", ops=100)
 
     def classTeardown(self):
         del self.gdb
@@ -866,6 +870,7 @@ class GdbSingleHartTest(GdbTest):
             if hart != self.hart:
                 self.gdb.select_hart(hart)
                 self.gdb.p("$pc=loop_forever")
+
         self.gdb.select_hart(self.hart)
 
 class ExamineTarget(GdbTest):


### PR DESCRIPTION
Change some tests from raw "GdbTest" to "SingleHartGdbTest". `SingleHartGdbTest`s are different in that they park all non-target harts at the `loop_forever` location. Some tests seemed to assume that behavior without actually telling the other harts to set their `$pc` to something (some `GdbTest`s manually set all hart's PC to `_start`, which is not something that GDB does automatically). This marks tests which are assuming single-hart behavior (i.e. assuming that the other harts won't interfere with what they are trying to do, regardless of what the other harts were doing when they were halted), and manually sets the PC for any that can't inherit from `SingleHartGdbTest`.