### PR TITLE
making mtvec_handler global

### DIFF
--- a/isa/rv32mi/shamt.S
+++ b/isa/rv32mi/shamt.S
@@ -21,6 +21,7 @@ RVTEST_CODE_BEGIN
 
   TEST_PASSFAIL
 
+.global mtvec_handler
 mtvec_handler:
   # Trapping on test 3 is good.
   # Note that since the test didn't complete, TESTNUM is smaller by 1.


### PR DESCRIPTION
Making the label global to override the existing label