### PR TITLE
Changing the register mstatus is read to

### DIFF
--- a/isa/rv64si/scall.S
+++ b/isa/rv64si/scall.S
@@ -34,8 +34,8 @@ RVTEST_CODE_BEGIN
   # Otherwise, if in S mode, then U mode must exist and we don't need to check.
   li t0, MSTATUS_MPP
   csrc mstatus, t0
-  csrr t1, mstatus
-  and t0, t0, t1
+  csrr t2, mstatus
+  and t0, t0, t2
   beqz t0, 1f
 
   # If U mode doesn't exist, mcause should indicate ECALL from M mode.


### PR DESCRIPTION
The mstatus reading overwrites the expected user mode cause value. this in turn causes the test to fail when a config has user mode