### PR TITLE
RV64 s{ll,ra,rl}w tests with non-canonical values

### DIFF
--- a/isa/rv64ui/slliw.S
+++ b/isa/rv64ui/slliw.S
@@ -35,6 +35,13 @@ RVTEST_CODE_BEGIN
   TEST_IMM_OP( 15, slliw, 0x0000000048484000, 0x0000000021212121, 14 );
   TEST_IMM_OP( 16, slliw, 0xffffffff80000000, 0x0000000021212121, 31 );
 
+  # Verify that shifts ignore top 32 (using true 64-bit values)
+
+  TEST_IMM_OP( 44, slliw, 0x0000000012345678, 0xffffffff12345678, 0 );
+  TEST_IMM_OP( 45, slliw, 0x0000000023456780, 0xffffffff12345678, 4 );
+  TEST_IMM_OP( 46, slliw, 0xffffffff92345678, 0x0000000092345678, 0 );
+  TEST_IMM_OP( 47, slliw, 0xffffffff93456780, 0x0000000099345678, 4 );
+
   #-------------------------------------------------------------
   # Source/Destination tests
   #-------------------------------------------------------------

--- a/isa/rv64ui/sllw.S
+++ b/isa/rv64ui/sllw.S
@@ -43,6 +43,13 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP( 20, sllw, 0x0000000048484000, 0x0000000021212121, 0xffffffffffffffee );
   TEST_RR_OP( 21, sllw, 0xffffffff80000000, 0x0000000021212121, 0xffffffffffffffff );
 
+  # Verify that shifts ignore top 32 (using true 64-bit values)
+
+  TEST_RR_OP( 44, sllw, 0x0000000012345678, 0xffffffff12345678, 0 );
+  TEST_RR_OP( 45, sllw, 0x0000000023456780, 0xffffffff12345678, 4 );
+  TEST_RR_OP( 46, sllw, 0xffffffff92345678, 0x0000000092345678, 0 );
+  TEST_RR_OP( 47, sllw, 0xffffffff93456780, 0x0000000099345678, 4 );
+
   #-------------------------------------------------------------
   # Source/Destination tests
   #-------------------------------------------------------------

--- a/isa/rv64ui/sraiw.S
+++ b/isa/rv64ui/sraiw.S
@@ -35,6 +35,13 @@ RVTEST_CODE_BEGIN
   TEST_IMM_OP( 15, sraiw, 0xfffffffffffe0606, 0xffffffff81818181, 14 );
   TEST_IMM_OP( 16, sraiw, 0xffffffffffffffff, 0xffffffff81818181, 31 );
 
+  # Verify that shifts ignore top 32 (using true 64-bit values)
+
+  TEST_IMM_OP( 44, sraiw, 0x0000000012345678, 0xffffffff12345678, 0 );
+  TEST_IMM_OP( 45, sraiw, 0x0000000001234567, 0xffffffff12345678, 4 );
+  TEST_IMM_OP( 46, sraiw, 0xffffffff92345678, 0x0000000092345678, 0 );
+  TEST_IMM_OP( 47, sraiw, 0xfffffffff9234567, 0x0000000092345678, 4 );
+
   #-------------------------------------------------------------
   # Source/Destination tests
   #-------------------------------------------------------------

--- a/isa/rv64ui/sraw.S
+++ b/isa/rv64ui/sraw.S
@@ -43,6 +43,13 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP( 20, sraw, 0xfffffffffffe0606, 0xffffffff81818181, 0xffffffffffffffee );
   TEST_RR_OP( 21, sraw, 0xffffffffffffffff, 0xffffffff81818181, 0xffffffffffffffff );
 
+  # Verify that shifts ignore top 32 (using true 64-bit values)
+
+  TEST_RR_OP( 44, sraw, 0x0000000012345678, 0xffffffff12345678, 0 );
+  TEST_RR_OP( 45, sraw, 0x0000000001234567, 0xffffffff12345678, 4 );
+  TEST_RR_OP( 46, sraw, 0xffffffff92345678, 0x0000000092345678, 0 );
+  TEST_RR_OP( 47, sraw, 0xfffffffff9234567, 0x0000000092345678, 4 );
+
   #-------------------------------------------------------------
   # Source/Destination tests
   #-------------------------------------------------------------

--- a/isa/rv64ui/srliw.S
+++ b/isa/rv64ui/srliw.S
@@ -35,6 +35,13 @@ RVTEST_CODE_BEGIN
   TEST_IMM_OP( 15, srliw, 0x0000000000008484, 0x0000000021212121, 14 );
   TEST_IMM_OP( 16, srliw, 0x0000000000000000, 0x0000000021212121, 31 );
 
+  # Verify that shifts ignore top 32 (using true 64-bit values)
+
+  TEST_IMM_OP( 44, srliw, 0x0000000012345678, 0xffffffff12345678, 0 );
+  TEST_IMM_OP( 45, srliw, 0x0000000001234567, 0xffffffff12345678, 4 );
+  TEST_IMM_OP( 46, srliw, 0xffffffff92345678, 0x0000000092345678, 0 );
+  TEST_IMM_OP( 47, srliw, 0x0000000009234567, 0x0000000092345678, 4 );
+
   #-------------------------------------------------------------
   # Source/Destination tests
   #-------------------------------------------------------------

--- a/isa/rv64ui/srlw.S
+++ b/isa/rv64ui/srlw.S
@@ -43,6 +43,13 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP( 20, srlw, 0x0000000000008484, 0x0000000021212121, 0xffffffffffffffee );
   TEST_RR_OP( 21, srlw, 0x0000000000000000, 0x0000000021212121, 0xffffffffffffffff );
 
+  # Verify that shifts ignore top 32 (using true 64-bit values)
+
+  TEST_RR_OP( 44, srlw, 0x0000000012345678, 0xffffffff12345678, 0 );
+  TEST_RR_OP( 45, srlw, 0x0000000001234567, 0xffffffff12345678, 4 );
+  TEST_RR_OP( 46, srlw, 0xffffffff92345678, 0x0000000092345678, 0 );
+  TEST_RR_OP( 47, srlw, 0x0000000009234567, 0x0000000092345678, 4 );
+
   #-------------------------------------------------------------
   # Source/Destination tests
   #-------------------------------------------------------------


### PR DESCRIPTION
The xxW variants should also be tested with values that are _not_ canonical 32-bit in 64-bit values.
As best I can tell, these pass of the current version of Spike.