### PR TITLE
Tweak debug tests to run out of flash.

### DIFF
--- a/debug/programs/debug.c
+++ b/debug/programs/debug.c
@@ -53,11 +53,8 @@ int main()
 
     volatile int i = 0;
     int j = 0;
-    static char fox[43];
+    char fox[] = "The quick brown fox jumps of the lazy dog.";
     unsigned int checksum = 0;
-
-    /* fox needs to be writable, but the string could be in ROM. */
-    strcpy(fox, "The quick brown fox jumps of the lazy dog.");
 
 start:
     while (i)

--- a/debug/programs/debug.c
+++ b/debug/programs/debug.c
@@ -53,8 +53,11 @@ int main()
 
     volatile int i = 0;
     int j = 0;
-    char *fox = "The quick brown fox jumps of the lazy dog.";
+    static char fox[43];
     unsigned int checksum = 0;
+
+    /* fox needs to be writable, but the string could be in ROM. */
+    strcpy(fox, "The quick brown fox jumps of the lazy dog.");
 
 start:
     while (i)

--- a/debug/programs/regs.S
+++ b/debug/programs/regs.S
@@ -52,6 +52,7 @@ write_regs:
 all_done:
         j       all_done
 
+        .section .bss
         .balign  16
 data:
         .fill   64, 8, 0

--- a/debug/programs/trigger.S
+++ b/debug/programs/trigger.S
@@ -93,7 +93,7 @@ read_triggers:
 1:      SREG    zero, 0(a0)
         ret
 
-        .data
+        .section .data
         .align  3
 data:   .word   0x40
         .word   0x41

--- a/debug/targets/SiFive/HiFive1-flash.lds
+++ b/debug/targets/SiFive/HiFive1-flash.lds
@@ -1,0 +1,44 @@
+OUTPUT_ARCH( "riscv" )
+
+MEMORY
+{
+    flash (rxl) : ORIGIN = 0x20400000, LENGTH = 128K
+    ram (wx) : ORIGIN = 0x80000000, LENGTH = 16K
+}
+
+SECTIONS
+{
+  flash_text : {
+    *(.text.entry)
+    *(.text)
+  } >flash
+
+  /* data segment */
+  .data : { *(.data) } >ram
+
+  .sdata : {
+    __global_pointer$ = . + 0x800;
+    *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2)
+    *(.srodata*)
+    *(.sdata .sdata.* .gnu.linkonce.s.*)
+  } >ram
+
+  /* bss segment */
+  __bss_start = .;
+  .sbss : {
+    *(.sbss .sbss.* .gnu.linkonce.sb.*)
+    *(.scommon)
+  } >ram
+  .bss : { *(.bss) } >ram
+  __bss_end = .;
+
+  __malloc_start = .;
+  . = . + 512;
+
+  /* End of uninitalized data segement */
+  _end = .;
+}
+
+ENTRY(_start)
+
+ASSERT(_end < 0x80004000, "program is too large")

--- a/debug/targets/SiFive/HiFive1-flash.py
+++ b/debug/targets/SiFive/HiFive1-flash.py
@@ -1,0 +1,15 @@
+import targets
+
+# Like HiFive1, but put code in flash
+
+class HiFive1FlashHart(targets.Hart):
+    xlen = 32
+    ram = 0x80000000
+    ram_size = 16 * 1024
+    instruction_hardware_breakpoint_count = 2
+    misa = 0x40001105
+    link_script_path = "HiFive1-flash.lds"
+
+class HiFive1Flash(targets.Target):
+    harts = [HiFive1FlashHart()]
+    openocd_config_path = "HiFive1.cfg"

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -579,7 +579,9 @@ class Gdb(object):
         output = self.command("b %s" % location, ops=5)
         assert "not defined" not in output
         assert "Breakpoint" in output
-        return output
+        m = re.search(r"Breakpoint (\d+),? ", output)
+        assert m, output
+        return int(m.group(1))
 
     def hbreak(self, location):
         output = self.command("hbreak %s" % location, ops=5)

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -463,7 +463,7 @@ class Gdb(object):
                 self.select_child(child)
                 self.command(command)
 
-    def c(self, wait=True, async=False):
+    def c(self, wait=True, async=False, checkOutput=True):
         """
         Dumb c command.
         In RTOS mode, gdb will resume all harts.
@@ -477,7 +477,9 @@ class Gdb(object):
         ops = 10
         if wait:
             output = self.command("c%s" % async, ops=ops)
-            assert "Continuing" in output
+            if checkOutput:
+                assert "Continuing" in output
+                assert "Could not insert hardware" not in output
             return output
         else:
             self.active_child.sendline("c%s" % async)
@@ -902,6 +904,7 @@ class GdbTest(BaseTest):
         if not self.gdb:
             return
         self.gdb.interrupt()
+        self.gdb.command("info breakpoints")
         self.gdb.command("disassemble", ops=20)
         self.gdb.command("info registers all", ops=100)
         self.gdb.command("flush regs")


### PR DESCRIPTION
Not all tests pass when run out of flash yet, but it's getting a lot
closer. The ones still failing on HiFive1-flash are: DebugSymbols,
Hwbp2, InstantHaltTest, TriggerDmode, TriggerLoadAddressInstant, and
TriggerStoreAddressInstant.