### PR TITLE
Added MemTestBlockReadInvalid verifying the corresponding OpenOCD fix

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -237,7 +237,7 @@ class MemTestBlockReadInvalid(GdbTest):
     real_values = "EF BE AD DE 78 56 34 12"
 
     def early_applicable(self):
-        return self.target.uses_dtm_version_013
+        return self.target.invalid_memory_returns_zero
 
     def test(self):
         self.gdb.p("*((int*)0x%x) = 0xdeadbeef" % (self.hart.ram + 0))
@@ -282,7 +282,7 @@ class MemTestBlockReadInvalid(GdbTest):
         self.gdb.command("shell cat %s" % dump.name)
         line = dump.readline()
         line = dump.readline()
-        assertEqual(line.strip(' \t\n\r'), expected_values)
+        assertEqual(line.strip(), expected_values)
 
 class MemTestBlock(GdbTest):
     length = 1024

--- a/debug/targets.py
+++ b/debug/targets.py
@@ -79,8 +79,8 @@ class Target(object):
     # hardware will every do that.
     implements_custom_test = False
 
-    # Target uses the DTM Version 0.13 for memory accesses
-    uses_dtm_version_013 = False
+    # When true it indicates that reading invalid memory doesn't return an error
+    invalid_memory_returns_zero = False
 
     # Internal variables:
     directory = None

--- a/debug/targets.py
+++ b/debug/targets.py
@@ -79,6 +79,9 @@ class Target(object):
     # hardware will every do that.
     implements_custom_test = False
 
+    # Target uses the DTM Version 0.13 for memory accesses
+    uses_dtm_version_013 = False
+
     # Internal variables:
     directory = None
     temporary_files = []

--- a/debug/targets/SiFive/Freedom/E300.py
+++ b/debug/targets/SiFive/Freedom/E300.py
@@ -10,4 +10,4 @@ class E300Hart(targets.Hart):
 class E300(targets.Target):
     openocd_config_path = "Freedom.cfg"
     harts = [E300Hart()]
-    uses_dtm_version_013 = True
+    invalid_memory_returns_zero = True

--- a/debug/targets/SiFive/Freedom/E300.py
+++ b/debug/targets/SiFive/Freedom/E300.py
@@ -3,10 +3,11 @@ import targets
 class E300Hart(targets.Hart):
     xlen = 32
     ram = 0x80000000
-    ram_size = 256 * 1024 * 1024
+    ram_size = 64 * 1024
     instruction_hardware_breakpoint_count = 2
     link_script_path = "Freedom.lds"
 
 class E300(targets.Target):
     openocd_config_path = "Freedom.cfg"
     harts = [E300Hart()]
+    uses_dtm_version_013 = True

--- a/debug/targets/SiFive/Freedom/U500.py
+++ b/debug/targets/SiFive/Freedom/U500.py
@@ -10,4 +10,4 @@ class U500Hart(targets.Hart):
 class U500(targets.Target):
     openocd_config_path = "Freedom.cfg"
     harts = [U500Hart()]
-    uses_dtm_version_013 = True
+    invalid_memory_returns_zero = True

--- a/debug/targets/SiFive/Freedom/U500.py
+++ b/debug/targets/SiFive/Freedom/U500.py
@@ -3,10 +3,11 @@ import targets
 class U500Hart(targets.Hart):
     xlen = 64
     ram = 0x80000000
-    ram_size = 16 * 1024
+    ram_size = 64 * 1024
     instruction_hardware_breakpoint_count = 2
     link_script_path = "Freedom.lds"
 
 class U500(targets.Target):
     openocd_config_path = "Freedom.cfg"
     harts = [U500Hart()]
+    uses_dtm_version_013 = True


### PR DESCRIPTION
Testing that memory reads with OpenOCD through the DTM Version 0.13 does not fail even if the memory range generates an exception from target, but instead returns zero values for the memory locations that is not really readable.