### PR TITLE
Added feature to compile riscv-tests without benchmarks

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -11,13 +11,20 @@ instbasedir     := $(DESTDIR)$(prefix)
 bmarkdir        := $(abs_top_src_dir)/benchmarks
 isa_src_dir     := $(abs_top_src_dir)/isa
 debug_src_dir   := $(abs_top_src_dir)/debug
+all_list        := @BENCHMARKS@ @ISA@
+install_list    := $(addprefix install_, $(all_list))
 
-all: benchmarks isa
 
-install: all
+all: $(all_list)
+
+install: $(install_list)
+
+install_isa: isa
 	install -d $(instbasedir)/share/riscv-tests/isa
-	install -d $(instbasedir)/share/riscv-tests/benchmarks
 	install -p -m 644 `find isa -maxdepth 1 -type f` $(instbasedir)/share/riscv-tests/isa
+
+install_benchmarks: benchmarks
+	install -d $(instbasedir)/share/riscv-tests/benchmarks
 	install -p -m 644 `find benchmarks -maxdepth 1 -type f` $(instbasedir)/share/riscv-tests/benchmarks
 
 benchmarks:

--- a/configure
+++ b/configure
@@ -584,6 +584,8 @@ PACKAGE_URL=''
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 XLEN
+BENCHMARKS
+ISA
 OBJEXT
 EXEEXT
 ac_ct_CC
@@ -633,6 +635,8 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 with_xlen
+with_benchmarks
+with_isa
 '
       ac_precious_vars='build_alias
 host_alias
@@ -2533,6 +2537,19 @@ else
 
 fi
 
+BENCHMARKS=benchmarks
+if test "${with_benchmarks+set}" = set; then :
+  if test $with_benchmarks = no; then :
+    BENCHMARKS=
+  fi
+fi
+
+ISA=isa
+if test "${with_isa+set}" = set; then :
+  if test $with_isa = no; then :
+    ISA=
+  fi
+fi
 
 
 ac_config_files="$ac_config_files Makefile"


### PR DESCRIPTION
Added feature to compile riscv-tests without benchmarks
(for extensions other than RV64IMAFDC)