### PR TITLE
Fix comments for shift amount.

### DIFF
--- a/isa/rv64ui/sll.S
+++ b/isa/rv64ui/sll.S
@@ -35,7 +35,7 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP( 15, sll, 0x0000084848484000, 0x0000000021212121, 14 );
   TEST_RR_OP( 16, sll, 0x1090909080000000, 0x0000000021212121, 31 );
 
-  # Verify that shifts only use bottom six bits
+  # Verify that shifts only use bottom six(rv64) or five(rv32) bits
 
   TEST_RR_OP( 17, sll, 0x0000000021212121, 0x0000000021212121, 0xffffffffffffffc0 );
   TEST_RR_OP( 18, sll, 0x0000000042424242, 0x0000000021212121, 0xffffffffffffffc1 );

--- a/isa/rv64ui/sra.S
+++ b/isa/rv64ui/sra.S
@@ -35,7 +35,7 @@ RVTEST_CODE_BEGIN
   TEST_RR_OP( 15, sra, 0xfffffffffffe0606, 0xffffffff81818181, 14 );
   TEST_RR_OP( 16, sra, 0xffffffffffffffff, 0xffffffff81818181, 31 );
 
-  # Verify that shifts only use bottom five bits
+  # Verify that shifts only use bottom six(rv64) or five(rv32) bits
 
   TEST_RR_OP( 17, sra, 0xffffffff81818181, 0xffffffff81818181, 0xffffffffffffffc0 );
   TEST_RR_OP( 18, sra, 0xffffffffc0c0c0c0, 0xffffffff81818181, 0xffffffffffffffc1 );

--- a/isa/rv64ui/srl.S
+++ b/isa/rv64ui/srl.S
@@ -38,7 +38,7 @@ RVTEST_CODE_BEGIN
   TEST_SRL( 15, 0x0000000021212121, 14 );
   TEST_SRL( 16, 0x0000000021212121, 31 );
 
-  # Verify that shifts only use bottom five bits
+  # Verify that shifts only use bottom six(rv64) or five(rv32) bits
 
   TEST_RR_OP( 17, srl, 0x0000000021212121, 0x0000000021212121, 0xffffffffffffffc0 );
   TEST_RR_OP( 18, srl, 0x0000000010909090, 0x0000000021212121, 0xffffffffffffffc1 );


### PR DESCRIPTION
Thank you for the very usefull test repository.

For `sll`, `srl`, `sra` insts, we have to consider the some low bits of rs2 as shift amount.
And according to the RISC-V spec 2.2, the bit width is

- 5 bits (in RV32)
- 6 bits (in RV64)

Current implementation has some unclear comments.
So I'd like to clarify them with this pull-req.