### PR TITLE
Cover with/without halt groups.

### DIFF
--- a/debug/targets/RISC-V/spike32-2-hwthread.py
+++ b/debug/targets/RISC-V/spike32-2-hwthread.py
@@ -8,7 +8,7 @@ class spike32_2(targets.Target):
     openocd_config_path = "spike-2-hwthread.cfg"
     timeout_sec = 5
     implements_custom_test = True
-    support_hasel = False
 
     def create(self):
-        return testlib.Spike(self, support_hasel=False)
+        return testlib.Spike(self, support_hasel=True,
+                support_haltgroups=False)

--- a/debug/targets/RISC-V/spike32-2-rtos.py
+++ b/debug/targets/RISC-V/spike32-2-rtos.py
@@ -12,4 +12,5 @@ class spike32_2(targets.Target):
 
     def create(self):
         return testlib.Spike(self, progbufsize=0, dmi_rti=4,
-                support_hasel=False, support_abstract_csr=True)
+                support_hasel=False, support_abstract_csr=True,
+                support_haltgroups=False)

--- a/debug/targets/RISC-V/spike32-2.py
+++ b/debug/targets/RISC-V/spike32-2.py
@@ -11,4 +11,4 @@ class spike32_2(targets.Target):
 
     def create(self):
         return testlib.Spike(self, isa="RV32IMAFC", progbufsize=0, dmi_rti=4,
-                support_abstract_csr=True)
+                support_abstract_csr=True, support_haltgroups=False)

--- a/debug/targets/RISC-V/spike32.py
+++ b/debug/targets/RISC-V/spike32.py
@@ -18,4 +18,4 @@ class spike32(targets.Target):
     def create(self):
         # 64-bit FPRs on 32-bit target
         return testlib.Spike(self, isa="RV32IMAFDC", dmi_rti=4,
-                support_abstract_csr=True)
+                support_abstract_csr=True, support_haltgroups=False)


### PR DESCRIPTION
Also work with the new command line options that were renamed in
https://github.com/riscv/riscv-isa-sim/pull/299