### PR TITLE
change alignment in handler to 4 bytes and add 4 byte alignment to pass and fail labels

### DIFF
--- a/isa/macros/scalar/test_macros.h
+++ b/isa/macros/scalar/test_macros.h
@@ -634,8 +634,10 @@ test_ ## testnum: \
 
 #define TEST_PASSFAIL \
         bne x0, TESTNUM, pass; \
+.align 4; \
 fail: \
         RVTEST_FAIL; \
+.align 4; \
 pass: \
         RVTEST_PASS \
 

--- a/isa/rv64si/ma_fetch.S
+++ b/isa/rv64si/ma_fetch.S
@@ -155,7 +155,7 @@ RVTEST_CODE_BEGIN
 
   TEST_PASSFAIL
 
-  .align 2
+  .align 4
   .global stvec_handler
 stvec_handler:
   # tests 2, 4, 5, 6, and 8 should trap


### PR DESCRIPTION
In some of the compiles, the pass, handler and fail labels are misaligned. This should fix the misalignment