### PR TITLE
Miscellaneous minor test improvements

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -13,7 +13,7 @@ import testlib
 from testlib import assertEqual, assertNotEqual, assertIn, assertNotIn
 from testlib import assertGreater, assertRegexpMatches, assertLess
 from testlib import GdbTest, GdbSingleHartTest, TestFailed
-from testlib import assertTrue
+from testlib import assertTrue, TestNotApplicable
 
 MSTATUS_UIE = 0x00000001
 MSTATUS_SIE = 0x00000002
@@ -535,7 +535,7 @@ class DebugBreakpoint(DebugTest):
 class Hwbp1(DebugTest):
     def test(self):
         if self.hart.instruction_hardware_breakpoint_count < 1:
-            return 'not_applicable'
+            raise TestNotApplicable
 
         if not self.hart.honors_tdata1_hmode:
             # Run to main before setting the breakpoint, because startup code
@@ -557,7 +557,7 @@ class Hwbp1(DebugTest):
 class Hwbp2(DebugTest):
     def test(self):
         if self.hart.instruction_hardware_breakpoint_count < 2:
-            return 'not_applicable'
+            raise TestNotApplicable
 
         self.gdb.command("delete")
         self.gdb.hbreak("main")
@@ -799,7 +799,7 @@ class MulticoreRunAllHaltOne(GdbTest):
 
     def test(self):
         if not self.gdb.one_hart_per_gdb():
-            return 'not_applicable'
+            raise TestNotApplicable
 
         # Run harts in reverse order
         for h in reversed(self.target.harts):
@@ -827,7 +827,7 @@ class MulticoreRtosSwitchActiveHartTest(GdbTest):
 
     def test(self):
         if self.gdb.one_hart_per_gdb():
-            return 'not_applicable'
+            raise TestNotApplicable
 
         # Set breakpoint near '_start' label to increase the chances of a
         # situation when all harts hit breakpoint immediately and
@@ -856,7 +856,7 @@ class SmpSimultaneousRunHalt(GdbTest):
 
     def test(self):
         if self.gdb.one_hart_per_gdb() or not self.server.smp():
-            return 'not_applicable'
+            raise TestNotApplicable
 
         old_mtime = set()
         for _ in range(5):
@@ -1226,7 +1226,7 @@ class PrivChange(PrivTest):
         """Test that the core's privilege level actually changes."""
 
         if 0 not in self.supported:
-            return 'not_applicable'
+            raise TestNotApplicable
 
         self.gdb.b("main")
         self.gdb.c()

--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -119,7 +119,6 @@ class SimpleT1Test(SimpleRegisterTest):
 class SimpleF18Test(SimpleRegisterTest):
     def check_reg(self, name, alias):
         if self.hart.extensionSupported('F'):
-            self.gdb.p_raw("$mstatus=$mstatus | 0x00006000")
             self.gdb.stepi()
             a = random.random()
             b = random.random()

--- a/debug/targets.py
+++ b/debug/targets.py
@@ -43,8 +43,7 @@ class Hart(object):
         # target.misa is set by testlib.ExamineTarget
         if self.misa:
             return self.misa & (1 << (ord(letter.upper()) - ord('A')))
-        else:
-            return False
+        return False
 
 class Target(object):
     # pylint: disable=too-many-instance-attributes

--- a/debug/targets/RISC-V/spike64-2.py
+++ b/debug/targets/RISC-V/spike64-2.py
@@ -6,7 +6,9 @@ import spike64  # pylint: disable=import-error
 class spike64_2(targets.Target):
     harts = [spike64.spike64_hart(), spike64.spike64_hart()]
     openocd_config_path = "spike-2.cfg"
-    timeout_sec = 10
+    # Increased timeout because we use abstract_rti to artificially slow things
+    # down.
+    timeout_sec = 20
     implements_custom_test = True
     support_hasel = False
 

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -583,7 +583,7 @@ class Gdb(object):
         return output.split('=', 1)[-1].strip()
 
     def p(self, obj, fmt="/x", ops=1):
-        output = self.command("p%s %s" % (fmt, obj), ops=ops)
+        output = self.command("p%s %s" % (fmt, obj), ops=ops).splitlines()[-1]
         m = re.search("Cannot access memory at address (0x[0-9a-f]+)", output)
         if m:
             raise CannotAccess(int(m.group(1), 0))

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -518,26 +518,27 @@ class Gdb(object):
                 self.select_child(child)
                 self.command(command)
 
-    def c(self, wait=True, async=False, checkOutput=True, ops=20):
+    def c(self, wait=True, sync=True, checkOutput=True, ops=20):
         """
         Dumb c command.
         In RTOS mode, gdb will resume all harts.
         In multi-gdb mode, this command will just go to the current gdb, so
         will only resume one hart.
         """
-        if async:
-            async = "&"
+        if sync:
+            sync = ""
         else:
-            async = ""
+            sync = "&"
         if wait:
-            output = self.command("c%s" % async, ops=ops)
+            output = self.command("c%s" % sync, ops=ops)
             if checkOutput:
                 assert "Continuing" in output
                 assert "Could not insert hardware" not in output
             return output
         else:
-            self.active_child.sendline("c%s" % async)
+            self.active_child.sendline("c%s" % sync)
             self.active_child.expect("Continuing", timeout=ops * self.timeout)
+            return ""
 
     def c_all(self, wait=True):
         """
@@ -1020,7 +1021,7 @@ class TestFailed(Exception):
             self.message += ": %s" % comment
 
 class TestNotApplicable(Exception):
-    def __init__(self, message):
+    def __init__(self, message=""):
         Exception.__init__(self)
         self.message = message
 


### PR DESCRIPTION
* Let the debugger enable mstatus.F if necessary. Don't do it in the test.
* Ignore (some) gdb debug output.
* Increase timeout for artificially slowed-down spike target.
* Make newer version of pylint happy.