### PR TITLE
Remove ocd_ prefix.

### DIFF
--- a/debug/targets/RISC-V/spike-1.cfg
+++ b/debug/targets/RISC-V/spike-1.cfg
@@ -22,7 +22,7 @@ riscv expose_custom 1,12345-12348
 
 init
 
-set challenge [ocd_riscv authdata_read]
+set challenge [riscv authdata_read]
 riscv authdata_write [expr $challenge + 1]
 
 halt

--- a/debug/targets/RISC-V/spike-2-hwthread.cfg
+++ b/debug/targets/RISC-V/spike-2-hwthread.cfg
@@ -25,7 +25,7 @@ riscv expose_custom 1,12345-12348
 
 init
 
-set challenge [ocd_riscv authdata_read]
+set challenge [riscv authdata_read]
 riscv authdata_write [expr $challenge + 1]
 
 halt

--- a/debug/targets/RISC-V/spike-2.cfg
+++ b/debug/targets/RISC-V/spike-2.cfg
@@ -23,7 +23,7 @@ riscv expose_custom 1,12345-12348
 
 init
 
-set challenge [ocd_riscv authdata_read]
+set challenge [riscv authdata_read]
 riscv authdata_write [expr $challenge + 1]
 
 targets $_TARGETNAME_0

--- a/debug/targets/RISC-V/spike-rtos.cfg
+++ b/debug/targets/RISC-V/spike-rtos.cfg
@@ -21,7 +21,7 @@ riscv expose_custom 1,12345-12348
 
 init
 
-set challenge [ocd_riscv authdata_read]
+set challenge [riscv authdata_read]
 riscv authdata_write [expr $challenge + 1]
 
 halt


### PR DESCRIPTION
The latest OpenOCD doesn't need (nor support) this anymore.