### PR TITLE
Improve parallellism in debug test Makefile

### DIFF
--- a/debug/Makefile
+++ b/debug/Makefile
@@ -12,9 +12,6 @@ all-tests: spike32 spike32-2 spike32-2-rtos spike32-2-hwthread \
 
 all:	pylint all-tests
 
-foo:
-	echo $(foreach test, $(TESTS), spike$@.$(test).run)
-
 run.%:
 	echo $@
 	$(GDBSERVER_PY) \

--- a/debug/Makefile
+++ b/debug/Makefile
@@ -3,6 +3,7 @@ XLEN ?= 64
 
 src_dir ?= .
 GDBSERVER_PY = $(src_dir)/gdbserver.py
+TESTS = $(shell $(GDBSERVER_PY) --list-tests $(src_dir)/targets/RISC-V/spike32.py)
 
 default: spike$(XLEN) spike$(XLEN)-2
 
@@ -11,19 +12,27 @@ all-tests: spike32 spike32-2 spike32-2-rtos spike32-2-hwthread \
 
 all:	pylint all-tests
 
+foo:
+	echo $(foreach test, $(TESTS), spike$@.$(test).run)
+
+run.%:
+	echo $@
+	$(GDBSERVER_PY) \
+		$(src_dir)/targets/RISC-V/$(word 2, $(subst ., ,$@)).py \
+		$(word 3, $(subst ., ,$@)) \
+		--isolate \
+		--print-failures \
+		--sim_cmd $(RISCV)/bin/$(RISCV_SIM) \
+		--server_cmd $(RISCV)/bin/openocd
+
 # Target to check all the multicore options.
 multi-tests: spike32-2 spike64-2-rtos spike32-2-hwthread
 
 pylint:
 	pylint --rcfile=pylint.rc `git ls-files '*.py'`
 
-spike%:
-	$(GDBSERVER_PY) \
-		--isolate \
-		--print-failures \
-		$(src_dir)/targets/RISC-V/$@.py \
-		--sim_cmd $(RISCV)/bin/$(RISCV_SIM) \
-		--server_cmd $(RISCV)/bin/openocd
+spike%:	$(foreach test, $(TESTS), run.spike%.$(test))
+	echo Finished $@
 
 clean:
 	rm -f *.pyc


### PR DESCRIPTION
Now each test is an individual make target, so you can get the most out
of however many cores you have. On my 12-core system, `make` went from
2m45s to 42s, and `make all` went from `3m25s` to `2m39s`.

If you have few cores, this change may actually slow things down a bit,
because ExamineTarget is run for every gdbserver.py invocation.