### PR TITLE
benchmarks: Simplify TLS initialisation

### DIFF
--- a/benchmarks/common/crt.S
+++ b/benchmarks/common/crt.S
@@ -216,18 +216,6 @@ trap_entry:
   addi sp, sp, 272
   mret
 
-.section ".tdata.begin"
-.globl _tdata_begin
-_tdata_begin:
-
-.section ".tdata.end"
-.globl _tdata_end
-_tdata_end:
-
-.section ".tbss.end"
-.globl _tbss_end
-_tbss_end:
-
 .section ".tohost","aw",@progbits
 .align 6
 .globl tohost

--- a/benchmarks/common/syscalls.c
+++ b/benchmarks/common/syscalls.c
@@ -96,10 +96,9 @@ int __attribute__((weak)) main(int argc, char** argv)
 static void init_tls()
 {
   register void* thread_pointer asm("tp");
-  extern char _tls_data;
-  extern __thread char _tdata_begin, _tdata_end, _tbss_end;
+  extern char _tdata_begin, _tdata_end, _tbss_end;
   size_t tdata_size = &_tdata_end - &_tdata_begin;
-  memcpy(thread_pointer, &_tls_data, tdata_size);
+  memcpy(thread_pointer, &_tdata_begin, tdata_size);
   size_t tbss_size = &_tbss_end - &_tdata_end;
   memset(thread_pointer + tdata_size, 0, tbss_size);
 }

--- a/benchmarks/common/test.ld
+++ b/benchmarks/common/test.ld
@@ -49,15 +49,14 @@ SECTIONS
   /* thread-local data segment */
   .tdata :
   {
-    _tls_data = .;
-    *(.tdata.begin)
+    _tdata_begin = .;
     *(.tdata)
-    *(.tdata.end)
+    _tdata_end = .;
   }
   .tbss :
   {
     *(.tbss)
-    *(.tbss.end)
+    _tbss_end = .;
   }
 
   /* End of uninitalized data segement */


### PR DESCRIPTION
The symbols used to query the size of .tdata and .tbss need not be thread-local themselves; instead, make them linker script-provided non-thread-local symbols.