### PR TITLE
Hardcode misa values for all spike targets.

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -1251,6 +1251,14 @@ class PrivChange(PrivTest):
         pc = self.gdb.p("$pc")
         assertTrue(pc < main_address or pc > main_address + 0x100)
 
+class CheckMisa(GdbTest):
+    """Make sure the misa we're using is actually what the target exposes."""
+    def test(self):
+        for hart in self.target.harts:
+            self.gdb.select_hart(hart)
+            misa = self.gdb.p("$misa")
+            assertEqual(misa, hart.misa)
+
 parsed = None
 def main():
     parser = argparse.ArgumentParser(

--- a/debug/targets/RISC-V/spike32-2-hwthread.py
+++ b/debug/targets/RISC-V/spike32-2-hwthread.py
@@ -4,7 +4,8 @@ import testlib
 import spike32  # pylint: disable=import-error
 
 class spike32_2(targets.Target):
-    harts = [spike32.spike32_hart(), spike32.spike32_hart()]
+    harts = [spike32.spike32_hart(misa=0x40141129),
+            spike32.spike32_hart(misa=0x40141129)]
     openocd_config_path = "spike-2-hwthread.cfg"
     timeout_sec = 5
     implements_custom_test = True

--- a/debug/targets/RISC-V/spike32-2-rtos.py
+++ b/debug/targets/RISC-V/spike32-2-rtos.py
@@ -4,7 +4,8 @@ import testlib
 import spike32  # pylint: disable=import-error
 
 class spike32_2(targets.Target):
-    harts = [spike32.spike32_hart(), spike32.spike32_hart()]
+    harts = [spike32.spike32_hart(misa=0x40141129),
+            spike32.spike32_hart(misa=0x40141129)]
     openocd_config_path = "spike-rtos.cfg"
     timeout_sec = 30
     implements_custom_test = True

--- a/debug/targets/RISC-V/spike32-2.py
+++ b/debug/targets/RISC-V/spike32-2.py
@@ -4,7 +4,8 @@ import testlib
 import spike32  # pylint: disable=import-error
 
 class spike32_2(targets.Target):
-    harts = [spike32.spike32_hart(), spike32.spike32_hart()]
+    harts = [spike32.spike32_hart(misa=0x40141125),
+            spike32.spike32_hart(misa=0x40141125)]
     openocd_config_path = "spike-2.cfg"
     timeout_sec = 30
     implements_custom_test = True

--- a/debug/targets/RISC-V/spike32.py
+++ b/debug/targets/RISC-V/spike32.py
@@ -9,8 +9,11 @@ class spike32_hart(targets.Hart):
     reset_vectors = [0x1000]
     link_script_path = "spike32.lds"
 
+    def __init__(self, misa):
+        self.misa = misa
+
 class spike32(targets.Target):
-    harts = [spike32_hart()]
+    harts = [spike32_hart(misa=0x4014112d)]
     openocd_config_path = "spike-1.cfg"
     timeout_sec = 30
     implements_custom_test = True

--- a/debug/targets/RISC-V/spike64-2-hwthread.py
+++ b/debug/targets/RISC-V/spike64-2-hwthread.py
@@ -4,7 +4,8 @@ import testlib
 import spike64  # pylint: disable=import-error
 
 class spike64_2(targets.Target):
-    harts = [spike64.spike64_hart(), spike64.spike64_hart()]
+    harts = [spike64.spike64_hart(misa=0x8000000000141129),
+            spike64.spike64_hart(misa=0x8000000000141129)]
     openocd_config_path = "spike-2-hwthread.cfg"
     timeout_sec = 5
     implements_custom_test = True

--- a/debug/targets/RISC-V/spike64-2-rtos.py
+++ b/debug/targets/RISC-V/spike64-2-rtos.py
@@ -4,7 +4,8 @@ import testlib
 import spike64  # pylint: disable=import-error
 
 class spike64_2_rtos(targets.Target):
-    harts = [spike64.spike64_hart(), spike64.spike64_hart()]
+    harts = [spike64.spike64_hart(misa=0x8000000000141129),
+            spike64.spike64_hart(misa=0x8000000000141129)]
     openocd_config_path = "spike-rtos.cfg"
     timeout_sec = 60
     implements_custom_test = True

--- a/debug/targets/RISC-V/spike64-2.py
+++ b/debug/targets/RISC-V/spike64-2.py
@@ -4,7 +4,8 @@ import testlib
 import spike64  # pylint: disable=import-error
 
 class spike64_2(targets.Target):
-    harts = [spike64.spike64_hart(), spike64.spike64_hart()]
+    harts = [spike64.spike64_hart(misa=0x8000000000141129),
+            spike64.spike64_hart(misa=0x8000000000141129)]
     openocd_config_path = "spike-2.cfg"
     # Increased timeout because we use abstract_rti to artificially slow things
     # down.

--- a/debug/targets/RISC-V/spike64.py
+++ b/debug/targets/RISC-V/spike64.py
@@ -9,6 +9,9 @@ class spike64_hart(targets.Hart):
     reset_vectors = [0x1000]
     link_script_path = "spike64.lds"
 
+    def __init__(self, misa=0x8000000000141125):
+        self.misa = misa
+
 class spike64(targets.Target):
     harts = [spike64_hart()]
     openocd_config_path = "spike-1.cfg"


### PR DESCRIPTION
`make` now takes 31s, `make all` takes 1m53s.
The new CheckMisa test ensures that the misa value specified in the
configuration is correct.