### PR TITLE
Added CSR test cases on whether writing 0 to CSR works

### DIFF
--- a/isa/rv64si/csr.S
+++ b/isa/rv64si/csr.S
@@ -55,6 +55,8 @@ RVTEST_CODE_BEGIN
   TEST_CASE( 7, a0, 0xbad1dea, li a0, 0x0001dea; csrrc a0, sscratch, a0);
   TEST_CASE( 8, a0, 0xbad0000, li a0, 0x000beef; csrrs a0, sscratch, a0);
   TEST_CASE( 9, a0, 0xbadbeef, csrr a0, sscratch);
+  TEST_CASE(15, a0,         0, csrrwi a0, sscratch, 0; csrrwi a0, sscratch, 0xF);
+  TEST_CASE(16, a0,         0, csrw sscratch, zero; csrr a0, sscratch);
 
 #ifdef __MACHINE_MODE
   # Is F extension present?


### PR DESCRIPTION
This is something that might get overlooked by implementers because some CSR operations should ignore writes if source is x0.