### PR TITLE
Fixed bug in scall test when running in machine mode

### DIFF
--- a/isa/rv64si/scall.S
+++ b/isa/rv64si/scall.S
@@ -30,6 +30,10 @@ RVTEST_CODE_BEGIN
   li t1, CAUSE_USER_ECALL
 
 #ifdef __MACHINE_MODE
+  # register mtvec_handler
+  la t0, stvec_handler
+  csrw mtvec, t0
+
   # If running in M mode, use mstatus.MPP to check existence of U mode.
   # Otherwise, if in S mode, then U mode must exist and we don't need to check.
   li t0, MSTATUS_MPP


### PR DESCRIPTION
Since `stvec_handler` was defined to `mtvec_handler` _after_ using `RVTEST_CODE_BEGIN`, the macro still uses `stvec_handler`. This symbol does not exist in the end, so that it yields zero. For that reason, `mtvec` (`stvec` in the macro) is not set (see the `beqz` in line 156 of `env/p/riscv_test.h`). This has the consequence that the `ecall` in the test jumps to the normal `trap_vector`, which just jumps to `write_tohost` to report an error.

I can only guess what the intention of the test is, but I assume that the `ecall` executed in user mode should go to machine mode and jump to `stvec_handler`. Therefore, I'm setting `mtvec` manually in the test.

The patch works both for rv64mi and rv64si on gem5.

As far as I can see, this is the same issue as reported in #115.