### PR TITLE
Don't assume reset state of mscratch

### DIFF
--- a/isa/rv64si/csr.S
+++ b/isa/rv64si/csr.S
@@ -46,8 +46,8 @@ RVTEST_CODE_BEGIN
 #endif
 #endif
 
-  TEST_CASE(15, a0,         0, csrrwi a0, sscratch, 0; csrrwi a0, sscratch, 0xF);
   TEST_CASE(16, a0,         0, csrw sscratch, zero; csrr a0, sscratch);
+  TEST_CASE(15, a0,         0, csrrwi a0, sscratch, 0; csrrwi a0, sscratch, 0xF);
 
   csrwi sscratch, 3
   TEST_CASE( 2, a0,         3, csrr a0, sscratch);


### PR DESCRIPTION
The test currently assumes that mscratch is reset to 0 because it does a read before (concurrent with) the first write and it tests the read value.  The architecture has no such reset requirement.  This reorders test cases so the first access to mscratch is a write only.
