### PR TITLE
Setup a multilevel page table to avoid misaligned superpages caused by variable DRAM_BASE

### DIFF
--- a/isa/rv64si/dirty.S
+++ b/isa/rv64si/dirty.S
@@ -10,6 +10,10 @@
 #include "riscv_test.h"
 #include "test_macros.h"
 
+#if (DRAM_BASE >> 30 << 30) != DRAM_BASE
+# error This test requires DRAM_BASE be SV39 superpage-aligned
+#endif 
+
 RVTEST_RV64M
 RVTEST_CODE_BEGIN
 

--- a/isa/rv64si/dirty.S
+++ b/isa/rv64si/dirty.S
@@ -15,7 +15,7 @@ RVTEST_CODE_BEGIN
 
   # Turn on VM
   li a0, (SATP_MODE & ~(SATP_MODE<<1)) * SATP_MODE_SV39
-  la a1, superpage_table_1
+  la a1, page_table_1
   srl a1, a1, RISCV_PGSHIFT
   or a1, a1, a0
   csrw sptbr, a1
@@ -51,7 +51,7 @@ RVTEST_CODE_BEGIN
   csrc mstatus, t0
 
   # Make sure D bit is set
-  lw t0, leaf_pte_1
+  lw t0, page_table_1
   li a0, PTE_A | PTE_D
   and t0, t0, a0
   bne t0, a0, die
@@ -62,11 +62,11 @@ RVTEST_CODE_BEGIN
 
   # Make sure that superpage entries trap when PPN LSBs are set.
   li TESTNUM, 4
-  lw a0, superpage_table_1 - DRAM_BASE
+  lw a0, page_table_1 - DRAM_BASE
   or a0, a0, 1 << PTE_PPN_SHIFT
-  sw a0, superpage_table_1 - DRAM_BASE, t0
+  sw a0, page_table_1 - DRAM_BASE, t0
   sfence.vma
-  sw a0, superpage_table_1 - DRAM_BASE, t0
+  sw a0, page_table_1 - DRAM_BASE, t0
   j die
   
   RVTEST_PASS
@@ -83,7 +83,7 @@ mtvec_handler:
   li t1, 2
   bne TESTNUM, t1, 1f
   # Make sure D bit is clear
-  lw t0, leaf_pte_1
+  lw t0, page_table_1
   and t1, t0, PTE_D
   bnez t1, die
 skip:
@@ -97,12 +97,12 @@ skip:
   bne TESTNUM, t1, 1f
   # The implementation doesn't appear to set D bits in HW.
   # Make sure the D bit really is clear.
-  lw t0, leaf_pte_1
+  lw t0, page_table_1
   and t1, t0, PTE_D
   bnez t1, die
   # Set the D bit.
   or t0, t0, PTE_D
-  sw t0, leaf_pte_1, t1
+  sw t0, page_table_1, t1
   sfence.vma
   mret
 
@@ -122,22 +122,8 @@ RVTEST_DATA_BEGIN
 
   TEST_DATA
 
-#Setup a multi-level page table to avoid misaligned superpages caused by certain values of DRAM_BASE
-# DRAM_BASE + 0x1008: leaf PTE 1
-# DRAM_BASE + 0x1010: dummy
-# DRAM_BASE + 0x1018: leaf PTE 2
-# DRAM_BASE + 0x2000: superpage 2
-# DRAM_BASE + 0x3000: superpage 1
-
 .align 12
-.dword 0
-leaf_pte_1: .dword (((DRAM_BASE/RISCV_PGSIZE)+1) << PTE_PPN_SHIFT) | PTE_V | PTE_U | PTE_R | PTE_W | PTE_X | PTE_A
+page_table_1: .dword (DRAM_BASE/RISCV_PGSIZE << PTE_PPN_SHIFT) | PTE_V | PTE_U | PTE_R | PTE_W | PTE_X | PTE_A
 dummy: .dword 0
-#Point back to a superpage entry so that we can test if accesses to them trap when PPN LSBs are set
-leaf_pte_2: .dword (((DRAM_BASE/RISCV_PGSIZE)+3) << PTE_PPN_SHIFT) | PTE_V | PTE_U | PTE_R | PTE_W | PTE_X | PTE_A
-.align 12
-superpage_table_2: .dword (((DRAM_BASE/RISCV_PGSIZE)+1) << PTE_PPN_SHIFT) | PTE_V | PTE_U | PTE_A
-.align 12
-superpage_table_1: .dword (((DRAM_BASE/RISCV_PGSIZE)+2) << PTE_PPN_SHIFT) | PTE_V | PTE_U | PTE_A
 
 RVTEST_DATA_END

--- a/isa/rv64si/dirty.S
+++ b/isa/rv64si/dirty.S
@@ -15,7 +15,7 @@ RVTEST_CODE_BEGIN
 
   # Turn on VM
   li a0, (SATP_MODE & ~(SATP_MODE<<1)) * SATP_MODE_SV39
-  la a1, page_table_1
+  la a1, superpage_table_1
   srl a1, a1, RISCV_PGSHIFT
   or a1, a1, a0
   csrw sptbr, a1
@@ -51,7 +51,7 @@ RVTEST_CODE_BEGIN
   csrc mstatus, t0
 
   # Make sure D bit is set
-  lw t0, page_table_1
+  lw t0, leaf_pte_1
   li a0, PTE_A | PTE_D
   and t0, t0, a0
   bne t0, a0, die
@@ -62,11 +62,11 @@ RVTEST_CODE_BEGIN
 
   # Make sure that superpage entries trap when PPN LSBs are set.
   li TESTNUM, 4
-  lw a0, page_table_1 - DRAM_BASE
+  lw a0, superpage_table_1 - DRAM_BASE
   or a0, a0, 1 << PTE_PPN_SHIFT
-  sw a0, page_table_1 - DRAM_BASE, t0
+  sw a0, superpage_table_1 - DRAM_BASE, t0
   sfence.vma
-  sw a0, page_table_1 - DRAM_BASE, t0
+  sw a0, superpage_table_1 - DRAM_BASE, t0
   j die
   
   RVTEST_PASS
@@ -83,7 +83,7 @@ mtvec_handler:
   li t1, 2
   bne TESTNUM, t1, 1f
   # Make sure D bit is clear
-  lw t0, page_table_1
+  lw t0, leaf_pte_1
   and t1, t0, PTE_D
   bnez t1, die
 skip:
@@ -97,12 +97,12 @@ skip:
   bne TESTNUM, t1, 1f
   # The implementation doesn't appear to set D bits in HW.
   # Make sure the D bit really is clear.
-  lw t0, page_table_1
+  lw t0, leaf_pte_1
   and t1, t0, PTE_D
   bnez t1, die
   # Set the D bit.
   or t0, t0, PTE_D
-  sw t0, page_table_1, t1
+  sw t0, leaf_pte_1, t1
   sfence.vma
   mret
 
@@ -122,8 +122,22 @@ RVTEST_DATA_BEGIN
 
   TEST_DATA
 
+#Setup a multi-level page table to avoid misaligned superpages caused by certain values of DRAM_BASE
+# DRAM_BASE + 0x1008: leaf PTE 1
+# DRAM_BASE + 0x1010: dummy
+# DRAM_BASE + 0x1018: leaf PTE 2
+# DRAM_BASE + 0x2000: superpage 2
+# DRAM_BASE + 0x3000: superpage 1
+
 .align 12
-page_table_1: .dword (DRAM_BASE/RISCV_PGSIZE << PTE_PPN_SHIFT) | PTE_V | PTE_U | PTE_R | PTE_W | PTE_X | PTE_A
+.dword 0
+leaf_pte_1: .dword (((DRAM_BASE/RISCV_PGSIZE)+1) << PTE_PPN_SHIFT) | PTE_V | PTE_U | PTE_R | PTE_W | PTE_X | PTE_A
 dummy: .dword 0
+#Point back to a superpage entry so that we can test if accesses to them trap when PPN LSBs are set
+leaf_pte_2: .dword (((DRAM_BASE/RISCV_PGSIZE)+3) << PTE_PPN_SHIFT) | PTE_V | PTE_U | PTE_R | PTE_W | PTE_X | PTE_A
+.align 12
+superpage_table_2: .dword (((DRAM_BASE/RISCV_PGSIZE)+1) << PTE_PPN_SHIFT) | PTE_V | PTE_U | PTE_A
+.align 12
+superpage_table_1: .dword (((DRAM_BASE/RISCV_PGSIZE)+2) << PTE_PPN_SHIFT) | PTE_V | PTE_U | PTE_A
 
 RVTEST_DATA_END


### PR DESCRIPTION
The single-level page table setup works fine if DRAM_BASE is greater than or equal to 0x4000_0000, however if DRAM_BASE is below this (e.g. 0x2000_0000), the PPN LSBs in the single PTE are set and the core traps because of a misaligned superpage.

To avoid this, I created a multilevel page table specific to sv39 (3 levels). In this setup, `satp` points to`superpage_table_1`, which points to `superpage_table_2`, which points to one of the the leaf PTEs.

