### PR TITLE
Improve address translation tests

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -1293,12 +1293,6 @@ class TranslateTest(GdbTest):
     compile_args = ("programs/translate.c", )
 
     def setup(self):
-        # TODO: If we use a random hart, then we get into trouble because
-        # gdb_read_memory_packet() ignores which hart is currently selected, so
-        # we end up reading satp from hart 0 when the address translation might
-        # be set up on hart 1 only.
-        self.gdb.select_hart(self.target.harts[0])
-
         self.disable_pmp()
 
         self.gdb.load()

--- a/debug/testlib.py
+++ b/debug/testlib.py
@@ -1070,6 +1070,17 @@ class GdbTest(BaseTest):
 
         self.gdb.select_hart(self.hart)
 
+    def disable_pmp(self):
+        # Disable physical memory protection by allowing U mode access to all
+        # memory.
+        try:
+            self.gdb.p("$pmpcfg0=0xf")  # TOR, R, W, X
+            self.gdb.p("$pmpaddr0=0x%x" %
+                    ((self.hart.ram + self.hart.ram_size) >> 2))
+        except CouldNotFetch:
+            # PMP registers are optional
+            pass
+
 class GdbSingleHartTest(GdbTest):
     def classSetup(self):
         GdbTest.classSetup(self)


### PR DESCRIPTION
Now only test modes that are actually supported by hardware, and turn off PMP.

Now it passes on HiFive Unleashed if you hack the config file not to expose hart 0. (Otherwise it'll correctly report the test is not applicable.) There's still the deeper OpenOCD issue regarding memory accesses always happening through the first hart in a `-rtos hwthread` setup. I'll start looking at that, since it'll probably be a problem some day.