### PR TITLE
Move self-modifying 'fence.i' ops to .data memory section

### DIFF
--- a/isa/rv64ui/fence_i.S
+++ b/isa/rv64ui/fence_i.S
@@ -19,11 +19,12 @@ lh a1, insn+2
 
 # test I$ hit
 .align 6
-sh a0, 1f, t0
-sh a1, 1f+2, t0
+sh a0, 2f, t0
+sh a1, 2f+2, t0
 fence.i
 
-1: addi a3, a3, 222
+la a5, 2f
+jalr a6, a5, 0
 TEST_CASE( 2, a3, 444, nop )
 
 # test prefetcher hit
@@ -31,12 +32,13 @@ li a4, 100
 1: addi a4, a4, -1
 bnez a4, 1b
 
-sh a0, 1f, t0
-sh a1, 1f+2, t0
+sh a0, 3f, t0
+sh a1, 3f+2, t0
 fence.i
 
 .align 6
-1: addi a3, a3, 555
+la a5, 3f
+jalr a6, a5, 0
 TEST_CASE( 3, a3, 777, nop )
 
 TEST_PASSFAIL
@@ -50,5 +52,11 @@ RVTEST_DATA_BEGIN
 
 insn:
   addi a3, a3, 333
+
+2: addi a3, a3, 222
+jalr a5, a6, 0
+
+3: addi a3, a3, 555
+jalr a5, a6, 0
 
 RVTEST_DATA_END


### PR DESCRIPTION
This allows the `fence_i.S` tests to succeed if they are run directly from a non-volatile memory which does not support byte-addressed writes. I don't think that it changes the test logic appreciably, but I'm not exactly an expert.

I tested this on a GD32VF103 chip which I think implements the RV32IMAC ISA; it only needed a bit of extra startup logic to copy the `.data` section into RAM, like this snippet from its standard peripheral library:

```
la a0, _sidata
la a1, _sdata
la a2, _edata
bgeu a1, a2, 2f
1:
lw t0, (a0)
sw t0, (a1)
addi a0, a0, 4
addi a1, a1, 4
bltu a1, a2, 1b
2:
```

And I got the expected a0 = 0, a7 = 93 results:

```
(gdb) load
Loading section .text, size 0x254 lma 0x8000000
Loading section .data, size 0x20 lma 0x8000254
Loading section .tohost, size 0x48 lma 0x80002c0
Start address 0x8000000, load size 700
Transfer rate: 676 bytes/sec, 233 bytes/write.
(gdb) c
Continuing.
^C
Program received signal SIGINT, Interrupt.
0x08000036 in write_tohost () at ./fence_i.S:14
14	RVTEST_CODE_BEGIN
(gdb) i r
ra             0x0	0x0
sp             0x0	0x0
gp             0x1	0x1
tp             0x0	0x0
t0             0x200001bc	536871356
t1             0x0	0
t2             0x309	777
fp             0x0	0x0
s1             0x0	0
a0             0x0	0
a1             0x14d6	5334
a2             0x20000020	536870944
a3             0x309	777
a4             0x0	0
a5             0x20000014	536870932
a6             0x800020c	134218252
a7             0x5d	93
[...other registers set to 0...]
t5             0x20000036	536870966
t6             0x8	8
pc             0x8000036	0x8000036 <write_tohost>
```

It also seems to work with simulated CPU designs which store their program data in a simulated ROM module. But I'll defer to the maintainers on whether this is a worthwhile change. Thanks!