### PR TITLE
Change linker script to keep HTIF in its own page

### DIFF
--- a/benchmarks/common/test.ld
+++ b/benchmarks/common/test.ld
@@ -28,6 +28,7 @@ SECTIONS
   . = ALIGN(0x1000);
   .tohost : { *(.tohost) }
 
+  . = ALIGN(0x1000);
   .text : { *(.text) }
 
   /* data segment */


### PR DESCRIPTION
Since HTIF could be a hardware device, it must live in its own page in memory. This change makes that happen by aligning the following text section.