### PR TITLE
Add enable_rtos_riscv

### DIFF
--- a/debug/targets/RISC-V/spike-rtos.cfg
+++ b/debug/targets/RISC-V/spike-rtos.cfg
@@ -8,6 +8,8 @@ remote_bitbang_port $::env(REMOTE_BITBANG_PORT)
 set _CHIPNAME riscv
 jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x10e31913
 
+enable_rtos_riscv
+
 set _TARGETNAME $_CHIPNAME.cpu
 target create $_TARGETNAME riscv -chain-position $_TARGETNAME -rtos riscv
 


### PR DESCRIPTION
This is now required to use `-rtos riscv`.
Addresses the aside mentioned in #287.