### PR TITLE
Add -fno-builtin compile flag

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -37,7 +37,7 @@ bmarks = \
 
 RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
 RISCV_GCC ?= $(RISCV_PREFIX)gcc
-RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf
+RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin
 RISCV_LINK ?= $(RISCV_GCC) -T $(src_dir)/common/test.ld $(incs)
 RISCV_LINK_OPTS ?= -static -nostdlib -nostartfiles -lm -lgcc -T $(src_dir)/common/test.ld
 RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data


### PR DESCRIPTION
Using the latest version of riscv-gcc, the benchmarks compile incorrectly: `memset()` is compiled with a recursive call, just as described in https://github.com/riscv/riscv-gcc/issues/197. This leads to an infinite recursion and ultimately to a crash due to a stack overflow. Here is the corresponding part of `dhrystone.riscv.dump` compiled with the latest versions of riscv-tests and riscv-gcc:
``` 
0000000080002774 <memset>:
    80002774:	1141                	addi	sp,sp,-16
    80002776:	00c567b3          	or	a5,a0,a2
    8000277a:	e022                	sd	s0,0(sp)
    8000277c:	e406                	sd	ra,8(sp)
    8000277e:	8b9d                	andi	a5,a5,7
    80002780:	842a                	mv	s0,a0
    80002782:	00c506b3          	add	a3,a0,a2
    80002786:	cf81                	beqz	a5,8000279e <memset+0x2a>
    80002788:	00d57663          	bgeu	a0,a3,80002794 <memset+0x20>
    8000278c:	0ff5f593          	andi	a1,a1,255
    80002790:	fe5ff0ef          	jal	ra,80002774 <memset>  // recursion
    80002794:	60a2                	ld	ra,8(sp)
    80002796:	8522                	mv	a0,s0
    80002798:	6402                	ld	s0,0(sp)
    8000279a:	0141                	addi	sp,sp,16
    8000279c:	8082                	ret
    8000279e:	0ff5f593          	andi	a1,a1,255
    800027a2:	00859713          	slli	a4,a1,0x8
    800027a6:	8f4d                	or	a4,a4,a1
    800027a8:	01071593          	slli	a1,a4,0x10
    800027ac:	8f4d                	or	a4,a4,a1
    800027ae:	02071793          	slli	a5,a4,0x20
    800027b2:	8f5d                	or	a4,a4,a5
    800027b4:	fed570e3          	bgeu	a0,a3,80002794 <memset+0x20>
    800027b8:	87aa                	mv	a5,a0
    800027ba:	07a1                	addi	a5,a5,8
    800027bc:	fee7bc23          	sd	a4,-8(a5)
    800027c0:	fed7ede3          	bltu	a5,a3,800027ba <memset+0x46>
    800027c4:	60a2                	ld	ra,8(sp)
    800027c6:	8522                	mv	a0,s0
    800027c8:	6402                	ld	s0,0(sp)
    800027ca:	0141                	addi	sp,sp,16
    800027cc:	8082                	ret
```
As suggested in https://github.com/riscv/riscv-gcc/issues/197, compiling with `-fno-builtin` resolves this issue. However, I could not check how this impacts performance across platforms.