### PR TITLE
Add rd=x0 test case to csr test

### DIFF
--- a/isa/rv64si/csr.S
+++ b/isa/rv64si/csr.S
@@ -48,6 +48,7 @@ RVTEST_CODE_BEGIN
 
   TEST_CASE(20, a0,         0, csrw sscratch, zero; csrr a0, sscratch);
   TEST_CASE(21, a0,         0, csrrwi a0, sscratch, 0; csrrwi a0, sscratch, 0xF);
+  TEST_CASE(22, a0,      0x1f, csrrsi x0, sscratch, 0x10; csrr a0, sscratch);
 
   csrwi sscratch, 3
   TEST_CASE( 2, a0,         3, csrr a0, sscratch);


### PR DESCRIPTION
I'd like to suggest to add rd=x0 test case to csr test.

Background:

CSRRS(I) and CSRRC(I) read a csr register, do logical-or or logical-clear operation, update the csr register, and store the old csr register data to rd register.

When I developed [RISC-V cpu emulator in Rust](https://github.com/takahirox/riscv-rust), I first implemented the instructions as 1. read a csr register to rd register, 2. do logical operation between rd register and source, and 3. store the result to the csr register. But I realized this implementation is wrong later because if rd is x0 it does logical operation with zero (x0 is hardwired zero register) in 2.

The current csr test doesn't detect this bug because there is no rd=x0 test case. So I'd like to suggest to add rd=x0 csr test case. I think addition is just one line and it'd be reasonable.

I tested this change with spike and confirmed it keeps passing the csr tests.