### PR TITLE
Refactor rv64ud structural test to match format of other tests

### DIFF
--- a/isa/rv64ud/structural.S
+++ b/isa/rv64ud/structural.S
@@ -19,7 +19,8 @@ li x12, 1
 li x2, 0x3FF0000000000000
 li x1, 0x3F800000
 
-#define TEST(nops, errcode)     \
+#define TEST(testnum, nops, errcode)     \
+test_ ## testnum: \
   fmv.d.x  f4, x0    ;\
   fmv.s.x  f3, x0    ;\
   fmv.d.x  f2, x2    ;\
@@ -38,15 +39,19 @@ li x1, 0x3F800000
 2:fmv.d.x  f2, zero    ;\
   fmv.s.x  f1, zero    ;\
 
-TEST(;,2)
-TEST(nop,4)
-TEST(nop;nop,6)
-TEST(nop;nop;nop,8)
-TEST(nop;nop;nop;nop,10)
-TEST(nop;nop;nop;nop;nop,12)
-TEST(nop;nop;nop;nop;nop;nop,14)
+TEST(1,;,2)
+TEST(2,nop,4)
+TEST(3,nop;nop,6)
+TEST(4,nop;nop;nop,8)
+TEST(5,nop;nop;nop;nop,10)
+TEST(6,nop;nop;nop;nop;nop,12)
+TEST(7,nop;nop;nop;nop;nop;nop,14)
 
+pass:
 RVTEST_PASS
+
+fail:
+RVTEST_FAIL
 
 RVTEST_CODE_END
 

--- a/isa/rv64ud/structural.S
+++ b/isa/rv64ud/structural.S
@@ -19,8 +19,9 @@ li x12, 1
 li x2, 0x3FF0000000000000
 li x1, 0x3F800000
 
-#define TEST(testnum, nops, errcode)     \
+#define TEST(testnum, nops)     \
 test_ ## testnum: \
+  li  TESTNUM, testnum; \
   fmv.d.x  f4, x0    ;\
   fmv.s.x  f3, x0    ;\
   fmv.d.x  f2, x2    ;\
@@ -33,25 +34,21 @@ test_ ## testnum: \
   fmv.x.d  x4, f4    ;\
   fmv.x.s  x5, f3    ;\
   beq     x1, x5, 2f  ;\
-  RVTEST_FAIL ;\
+  j fail;\
 2:beq     x2, x4, 2f  ;\
-  RVTEST_FAIL; \
+  j fail; \
 2:fmv.d.x  f2, zero    ;\
   fmv.s.x  f1, zero    ;\
 
-TEST(1,;,2)
-TEST(2,nop,4)
-TEST(3,nop;nop,6)
-TEST(4,nop;nop;nop,8)
-TEST(5,nop;nop;nop;nop,10)
-TEST(6,nop;nop;nop;nop;nop,12)
-TEST(7,nop;nop;nop;nop;nop;nop,14)
+TEST(1,;)
+TEST(2,nop)
+TEST(3,nop;nop)
+TEST(4,nop;nop;nop)
+TEST(5,nop;nop;nop;nop)
+TEST(6,nop;nop;nop;nop;nop)
+TEST(7,nop;nop;nop;nop;nop;nop)
 
-pass:
-RVTEST_PASS
-
-fail:
-RVTEST_FAIL
+TEST_PASSFAIL
 
 RVTEST_CODE_END
 


### PR DESCRIPTION
Minor clean up of the rv64ud structural test to use the pass/fail macros and test numbers. This is just to make the test easier to debug - the test itself has not changed.