### PR TITLE
Make mtvec_handler's address to be multiple of 16

### DIFF
--- a/isa/rv32mi/shamt.S
+++ b/isa/rv32mi/shamt.S
@@ -21,6 +21,7 @@ RVTEST_CODE_BEGIN
 
   TEST_PASSFAIL
 
+.align 4
 .global mtvec_handler
 mtvec_handler:
   # Trapping on test 3 is good.


### PR DESCRIPTION
Setting mtvec_handler's address to be multiple of 16. This avoids overriding of mtvec_handler's address by writing it into mtvec CSR for certain configs.