### PR TITLE
Add the method to build riscv-tests on ARM in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ install path, and that the riscv-gnu-toolchain package is installed.
     $ make
     $ make install
 
+If you are on an ARM machine, e.g., Raspberry Pi 4 with Fedora Spin 33
+XFCE AArch64, you may use the similar configure arguments as below to
+cross-compile riscv-tests:
+./configure --prefix=$RISCV/target --build=aarch64-redhat-linux --host=riscv64-unknown-elf --target=riscv64-unknown-elf
+The above target triplets depends on your host system and the toolchain prefix according to $RISCV.
+
 The rest of this document describes the format of test programs for the RISC-V
 architecture.
 


### PR DESCRIPTION
Recently,  when I tried to build riscv-tests in order to test the Rocket Chip that built on my Raspberry Pi 4(abbreviated as "RPi4" from now on), it was found that the original guide of riscv-tests seems only focus on X86, and does not apply for ARM. After several attempts, finally, I successfully built riscv-tests on RPi4 and used it to do some tests against Rocket Chip, everything seems OK. 
Thus this pull request is made for as a reference for those who are going to develop RISC-V on ARM hardware like RPi4.