### PR TITLE
Fixes for illegal.S to support Bare-SMode and sbreak.S & scall.S to support CLIC mode.

### DIFF
--- a/isa/rv64mi/illegal.S
+++ b/isa/rv64mi/illegal.S
@@ -60,6 +60,18 @@ msip:
   # Make sure WFI doesn't trap when TW=0.
   wfi
 
+  # Check if paging is supported (Set SUM & MXR and read it back)
+  and t0, t0, zero
+  li t0, (SSTATUS_SUM | SSTATUS_MXR)
+  csrc sstatus, t0
+  and t1, t1, zero
+  li t1, (SSTATUS_SUM | SSTATUS_MXR) 
+  csrs sstatus, t1
+  csrr t2, sstatus
+  and t2, t2, t0
+  beqz t2, bare_s_1
+  csrc sstatus, t0
+
   # Make sure SFENCE.VMA and sptbr don't trap when TVM=0.
   sfence.vma
   csrr t0, sptbr
@@ -75,6 +87,7 @@ bad7:
   csrr t0, sptbr
   j fail
 
+test_tsr:
   # Make sure SRET doesn't trap when TSR=0.
   la t0, bad8
   csrw sepc, t0
@@ -94,7 +107,26 @@ bad9:
   sret
 1:
   j fail
+  j skip_bare_s
 
+bare_s_1:
+  # Make sure SFENCE.VMA trap when TVM=0.
+  sfence.vma
+  j fail
+
+bare_s_2:
+  # Set TVM=1. TVM should stay 0 and SFENCE.VMA should still trap 
+  sfence.vma
+  j fail
+
+  # And access to satp should not trap
+  csrr t0, sptbr
+bare_s_3:
+  .word 0
+  j fail
+  j test_tsr
+
+skip_bare_s:
   TEST_PASSFAIL
 
   .align 8
@@ -146,6 +178,12 @@ synchronous_exception:
   beq t0, t1, 8f
   la t1, bad9
   beq t0, t1, 9f
+  la t1, bare_s_1
+  beq t0, t1, 5f
+  la t1, bare_s_2
+  beq t0, t1, 7f
+  la t1, bare_s_3
+  beq t0, t1, 7f
   j fail
 2:
 6:

--- a/isa/rv64si/sbreak.S
+++ b/isa/rv64si/sbreak.S
@@ -35,6 +35,13 @@ do_break:
 stvec_handler:
   li t1, CAUSE_BREAKPOINT
   csrr t0, scause
+  # Check if CLIC mode
+  csrr t2, stvec
+  andi t2, t2, 2
+  # Skip masking if non-CLIC mode
+  beqz t2, skip_mask 
+  andi t0, t0, 255
+skip_mask:
   bne t0, t1, fail
   la t1, do_break
   csrr t0, sepc

--- a/isa/rv64si/scall.S
+++ b/isa/rv64si/scall.S
@@ -67,6 +67,13 @@ do_scall:
   .global stvec_handler
 stvec_handler:
   csrr t0, scause
+  # Check if CLIC mode
+  csrr t2, stvec
+  andi t2, t2, 2
+  # Skip masking if non-CLIC mode
+  beqz t2, skip_mask 
+  andi t0, t0, 255
+skip_mask:
   bne t0, t1, fail
   la t2, do_scall
   csrr t0, sepc


### PR DESCRIPTION
illegal.S:
- After the test enters supervisor mode, check if paging is supported.
- If paging is NOT supported (i.e. Bare S-mode), jump to a new section of code that checks the following:
-- SFENCE.VMA causing illegal instruction trap regardless of TVM.
-- Access to SATP does not trap.
-- Jump to the same TSR check as regular S-mode
-- End test

sbreak.S & scall.S:
- Before checking for scause, check if the core is in CLIC-mode (mtvec[1]).
- If we're in CLIC-mode, mask off scause bits[(XLEN-1):8] before checing its value.
- Otherwise, don't mask off any scause bits as in the original test.