### PR TITLE
Fix for rv64mi/sbreak and rv64mi/scall

### DIFF
--- a/isa/rv64si/sbreak.S
+++ b/isa/rv64si/sbreak.S
@@ -17,6 +17,7 @@ RVTEST_CODE_BEGIN
   #define sscratch mscratch
   #define sstatus mstatus
   #define scause mcause
+  #define stvec mtvec
   #define sepc mepc
   #define sret mret
   #define stvec_handler mtvec_handler

--- a/isa/rv64si/scall.S
+++ b/isa/rv64si/scall.S
@@ -17,6 +17,7 @@ RVTEST_CODE_BEGIN
   #define sscratch mscratch
   #define sstatus mstatus
   #define scause mcause
+  #define stvec mtvec
   #define sepc mepc
   #define sret mret
   #define stvec_handler mtvec_handler


### PR DESCRIPTION
Fix for rv64mi/sbreak and rv64mi/scall that I broke in my previous commit:
Added "#define stvec mtvec" under __MACHINE_MODE ifdef.