### PR TITLE
Tweaks for multispike.

### DIFF
--- a/debug/Makefile
+++ b/debug/Makefile
@@ -4,16 +4,19 @@ XLEN ?= 64
 src_dir ?= .
 GDBSERVER_PY = $(src_dir)/gdbserver.py
 TESTS = $(shell $(GDBSERVER_PY) --list-tests $(src_dir)/targets/RISC-V/spike32.py)
+MULTI_TESTS = $(shell $(GDBSERVER_PY) --list-tests $(src_dir)/targets/RISC-V/spike32.py | \
+	      grep -i multi)
 
 default: spike$(XLEN) spike$(XLEN)-2
 
-all-tests: spike32 spike32-2 spike32-2-hwthread \
-	spike64 spike64-2 spike64-2-hwthread spike-multi
+all-tests: spike32 spike-multi-limited spike32-2 spike32-2-hwthread \
+	spike64 spike64-2 spike64-2-hwthread
+
+slow-tests:	spike-multi all-tests
 
 all:	pylint all-tests
 
 run.%:
-	echo $@
 	$(GDBSERVER_PY) \
 		$(src_dir)/targets/RISC-V/$(word 2, $(subst ., ,$@)).py \
 		$(word 3, $(subst ., ,$@)) \
@@ -27,6 +30,9 @@ multi-tests: spike32-2 spike32-2-hwthread
 
 pylint:
 	pylint --rcfile=pylint.rc `git ls-files '*.py'`
+
+spike-multi-limited:	$(foreach test, $(MULTI_TESTS), run.spike-multi.$(test))
+	echo Finished $@
 
 spike%:	$(foreach test, $(TESTS), run.spike%.$(test))
 	echo Finished $@

--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -940,7 +940,7 @@ class Semihosting(GdbSingleHartTest):
 
         self.gdb.b("main:begin")
         self.gdb.c()
-        self.gdb.p('filename="%s"' % temp.name, ops=2)
+        self.gdb.p('filename="%s"' % temp.name, ops=3)
         self.exit()
 
         contents = open(temp.name, "r").readlines()


### PR DESCRIPTION
1. Don't run all tests in multi-spike. Extra coverage is negligible, and
it just takes too long.
2. Increase a few timeouts.