### PR TITLE
Debug tests: catch write to nonexistent trigger registers in entry.S

### DIFF
--- a/debug/programs/entry.S
+++ b/debug/programs/entry.S
@@ -71,6 +71,9 @@ handle_reset:
   addi  t0, t0, -1
   bnez  t0, 1b
 
+  # Catch trap in case trigger module is not implemented
+  la t2, 2f
+  csrrw t2, mtvec, t2
   # Clear all hardware triggers
   li    t0, ~0
 1:
@@ -79,6 +82,10 @@ handle_reset:
   csrw  CSR_TDATA1, zero
   csrr  t1, CSR_TSELECT
   beq   t0, t1, 1b
+.p2align 2
+2:
+  # Restore mtvec
+  csrw mtvec, t2
 
 #ifdef MULTICORE
   csrr  t0, CSR_MHARTID


### PR DESCRIPTION
The reset handler in `entry.S` attempts to clear all hardware triggers before starting the test. An implementation can be compliant without implementing the trigger module, in which case this access will trap and then spin forever in the trap handler. This breaks all software-based debug tests on targets which don't implement the trigger module. I hit this when bringing up the debug tests on my soft core.

This patch adds some trap-catch code around the trigger CSR accesses in the reset handler. Since the purpose of this routine is to clear any triggers which may be set, the code serves no purpose on targets with no trigger module, so the failure can be safely ignored, and startup can continue.