### PR TITLE
masking maskmax in breakpoints test

### DIFF
--- a/isa/rv64mi/breakpoint.S
+++ b/isa/rv64mi/breakpoint.S
@@ -27,6 +27,8 @@ RVTEST_CODE_BEGIN
   csrw tdata1, a0
   # Skip if breakpoint type is unsupported.
   csrr a1, tdata1
+  li a3, ~MCONTROL_MASKMAX(__riscv_xlen)
+  and a1, a1, a3
   bne a0, a1, 2f
   .align 2
 1:
@@ -44,6 +46,8 @@ RVTEST_CODE_BEGIN
   csrw tdata1, a0
   # Skip if breakpoint type is unsupported.
   csrr a1, tdata1
+  li a3, ~MCONTROL_MASKMAX(__riscv_xlen)
+  and a1, a1, a3
   bne a0, a1, 2f
   la a2, data1
   csrw tdata2, a2
@@ -63,6 +67,8 @@ RVTEST_CODE_BEGIN
   csrw tdata1, a0
   # Skip if breakpoint type is unsupported.
   csrr a1, tdata1
+  li a3, ~MCONTROL_MASKMAX(__riscv_xlen)
+  and a1, a1, a3
   bne a0, a1, 2f
 
   # Trap handler should skip this instruction.


### PR DESCRIPTION
Currently in rocket-chip, reading tdata1 will return the value "4" in the maskmax field.
This happens because of this line:
https://github.com/chipsalliance/rocket-chip/blob/7f214d564a57d3b1fa63e67a42a64629e76d53a2/src/main/scala/rocket/Breakpoint.scala#L30
Thus, the breakpoint.S test was always skipped and did not work.