### PR TITLE
zicntr: separate cycle/instret accessibility test

### DIFF
--- a/isa/rv32mi/Makefrag
+++ b/isa/rv32mi/Makefrag
@@ -12,9 +12,10 @@ rv32mi_sc_tests = \
 	scall \
 	sbreak \
 	shamt \
-        lw-misaligned \
-        lh-misaligned \
+	lw-misaligned \
+	lh-misaligned \
 	sh-misaligned \
 	sw-misaligned \
+	zicntr \
 
 rv32mi_p_tests = $(addprefix rv32mi-p-, $(rv32mi_sc_tests))

--- a/isa/rv32mi/zicntr.S
+++ b/isa/rv32mi/zicntr.S
@@ -1,0 +1,8 @@
+# See LICENSE for license details.
+
+#include "riscv_test.h"
+#undef RVTEST_RV64M
+#define RVTEST_RV64M RVTEST_RV32M
+#define __MACHINE_MODE
+
+#include "../rv64mi/zicntr.S"

--- a/isa/rv64mi/Makefrag
+++ b/isa/rv64mi/Makefrag
@@ -12,11 +12,12 @@ rv64mi_sc_tests = \
 	ma_addr \
 	scall \
 	sbreak \
-        ld-misaligned \
-        lw-misaligned \
-        lh-misaligned \
-        sh-misaligned \
-        sw-misaligned \
-        sd-misaligned \
+	ld-misaligned \
+	lw-misaligned \
+	lh-misaligned \
+	sh-misaligned \
+	sw-misaligned \
+	sd-misaligned \
+	zicntr \
 
 rv64mi_p_tests = $(addprefix rv64mi-p-, $(rv64mi_sc_tests))

--- a/isa/rv64mi/zicntr.S
+++ b/isa/rv64mi/zicntr.S
@@ -1,0 +1,51 @@
+# See LICENSE for license details.
+
+#*****************************************************************************
+# zicntr.S
+#-----------------------------------------------------------------------------
+#
+# Test if Zicntr is implemented correctly
+#
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV64M
+RVTEST_CODE_BEGIN
+
+  # Make sure reading the cycle counter in four ways doesn't trap.
+  TEST_CASE( 2, x0, 0, csrrc  x0, cycle,    x0);
+  TEST_CASE( 3, x0, 0, csrrs  x0, cycle,    x0);
+  TEST_CASE( 4, x0, 0, csrrci x0, cycle,    0);
+  TEST_CASE( 5, x0, 0, csrrsi x0, cycle,    0);
+  TEST_CASE( 6, x0, 0, csrrc  x0, instret,  x0);
+  TEST_CASE( 7, x0, 0, csrrs  x0, instret,  x0);
+  TEST_CASE( 8, x0, 0, csrrci x0, instret,  0);
+  TEST_CASE( 9, x0, 0, csrrsi x0, instret,  0);
+#if __riscv_xlen == 32
+  TEST_CASE(12, x0, 0, csrrc  x0, cycleh,   x0);
+  TEST_CASE(13, x0, 0, csrrs  x0, cycleh,   x0);
+  TEST_CASE(14, x0, 0, csrrci x0, cycleh,   0);
+  TEST_CASE(15, x0, 0, csrrsi x0, cycleh,   0);
+  TEST_CASE(16, x0, 0, csrrc  x0, instreth, x0);
+  TEST_CASE(17, x0, 0, csrrs  x0, instreth, x0);
+  TEST_CASE(18, x0, 0, csrrci x0, instreth, 0);
+  TEST_CASE(19, x0, 0, csrrsi x0, instreth, 0);
+#endif
+
+2:
+  TEST_PASSFAIL
+
+  .align 2
+  .global mtvec_handler
+mtvec_handler:
+  j fail
+
+RVTEST_CODE_END
+
+  .data
+RVTEST_DATA_BEGIN
+
+  TEST_DATA
+
+RVTEST_DATA_END

--- a/isa/rv64si/csr.S
+++ b/isa/rv64si/csr.S
@@ -46,14 +46,6 @@ RVTEST_CODE_BEGIN
 #endif
 #endif
 
-  # Make sure reading the cycle counter in four ways doesn't trap.
-#ifdef __MACHINE_MODE
-  TEST_CASE(25, x0, 0, csrrc  x0, cycle, x0);
-  TEST_CASE(26, x0, 0, csrrs  x0, cycle, x0);
-  TEST_CASE(27, x0, 0, csrrci x0, cycle, 0);
-  TEST_CASE(28, x0, 0, csrrsi x0, cycle, 0);
-#endif
-
   TEST_CASE(20, a0,         0, csrw sscratch, zero; csrr a0, sscratch);
   TEST_CASE(21, a0,         0, csrrwi a0, sscratch, 0; csrrwi a0, sscratch, 0xF);
   TEST_CASE(22, a0,      0x1f, csrrsi x0, sscratch, 0x10; csrr a0, sscratch);


### PR DESCRIPTION
It is allowed that M-mode only implementation could skip cycle/instret if the Zicntr is not included.

Signed-off-by: Chih-Min Chao <chihmin.chao@sifive.com>