### PR TITLE
Add more tests for amo[max/maxu/min/minu]_w

### DIFF
--- a/isa/rv64ua/amomax_w.S
+++ b/isa/rv64ua/amomax_w.S
@@ -31,6 +31,16 @@ RVTEST_CODE_BEGIN
 
   TEST_CASE(5, a5, 1, lw a5, 0(a3))
 
+  TEST_CASE(6, a4, 1, \
+    li a0, 0x0000000000000001; \
+    li a1, 0x0000000080000000; \
+    la a3, amo_operand; \
+    sw a0, 0(a3); \
+    amomax.w	a4, a1, 0(a3); \
+  )
+
+  TEST_CASE(7, a5, 1, lw a5, 0(a3))
+
   TEST_PASSFAIL
 
 RVTEST_CODE_END

--- a/isa/rv64ua/amomaxu_w.S
+++ b/isa/rv64ua/amomaxu_w.S
@@ -31,6 +31,16 @@ RVTEST_CODE_BEGIN
 
   TEST_CASE(5, a5, 0xffffffffffffffff, lw a5, 0(a3))
 
+  TEST_CASE(6, a4, 1, \
+    li a0, 0x0000000000000001; \
+    li a1, 0x8000000000000000; \
+    la a3, amo_operand; \
+    sw a0, 0(a3); \
+    amomaxu.w	a4, a1, 0(a3); \
+  )
+
+  TEST_CASE(7, a5, 1, lw a5, 0(a3))
+
   TEST_PASSFAIL
 
 RVTEST_CODE_END

--- a/isa/rv64ua/amomin_w.S
+++ b/isa/rv64ua/amomin_w.S
@@ -31,6 +31,16 @@ RVTEST_CODE_BEGIN
 
   TEST_CASE(5, a5, 0xffffffffffffffff, lw a5, 0(a3))
 
+  TEST_CASE(6, a4, 1, \
+    li a0, 0x0000000000000001; \
+    li a1, 0x0000000080000000; \
+    la a3, amo_operand; \
+    sw a0, 0(a3); \
+    amomin.w	a4, a1, 0(a3); \
+  )
+
+  TEST_CASE(7, a5, 0xffffffff80000000, lw a5, 0(a3))
+
   TEST_PASSFAIL
 
 RVTEST_CODE_END

--- a/isa/rv64ua/amominu_w.S
+++ b/isa/rv64ua/amominu_w.S
@@ -31,6 +31,16 @@ RVTEST_CODE_BEGIN
 
   TEST_CASE(5, a5, 0, lw a5, 0(a3))
 
+  TEST_CASE(6, a4, 1, \
+    li a0, 0x0000000000000001; \
+    li a1, 0x8000000000000000; \
+    la a3, amo_operand; \
+    sw a0, 0(a3); \
+    amominu.w	a4, a1, 0(a3); \
+  )
+
+  TEST_CASE(7, a5, 0, lw a5, 0(a3))
+
   TEST_PASSFAIL
 
 RVTEST_CODE_END
@@ -46,4 +56,3 @@ RVTEST_DATA_END
   .align 3
 amo_operand:
   .dword 0
-  


### PR DESCRIPTION
For RV64, 32-bit AMOs always sign-extend the value placed in rd, and ignore the upper 32 bits of the original value of rs2. 

This PR adds tests for this scenario.