### PR TITLE
Make sure that sc after failure sc fails

### DIFF
--- a/isa/rv64ua/lrsc.S
+++ b/isa/rv64ua/lrsc.S
@@ -97,7 +97,7 @@ TEST_CASE( 7, a1, 1, \
   addi a3, a0, 8; \
 1:lr.w a1, (a0); \
   sc.w a1, x0, (a3); \
-  bnez a1, 1b; \
+  beqz a1, 1b; \
   sc.w a1, x0, (a0)
 )
 

--- a/isa/rv64ua/lrsc.S
+++ b/isa/rv64ua/lrsc.S
@@ -91,6 +91,16 @@ TEST_CASE( 6, a1, 1, \
   sc.w a1, x0, (a0)
 )
 
+# make sure that sc-after-failure-sc fails.
+TEST_CASE( 7, a1, 1, \
+  la a0, foo; \
+  addi a3, a0, 8; \
+1:lr.w a1, (a0); \
+  sc.w a1, x0, (a3); \
+  bnez a1, 1b; \
+  sc.w a1, x0, (a0)
+)
+
 TEST_PASSFAIL
 
 RVTEST_CODE_END


### PR DESCRIPTION
Regardless of success or failure, executing an SC.W instruction invalidates any reservation held by this hart. So sc after failure sc must fails.