### PR TITLE
syscalls: use correct printf code for counters[]

### DIFF
--- a/benchmarks/common/syscalls.c
+++ b/benchmarks/common/syscalls.c
@@ -115,7 +115,7 @@ void _init(int cid, int nc)
   char* pbuf = buf;
   for (int i = 0; i < NUM_COUNTERS; i++)
     if (counters[i])
-      pbuf += sprintf(pbuf, "%s = %d\n", counter_names[i], counters[i]);
+      pbuf += sprintf(pbuf, "%s = %lu\n", counter_names[i], counters[i]);
   if (pbuf != buf)
     printstr(buf);
 


### PR DESCRIPTION
Building benchmarks/common/syscalls.c results in a warning:

    warning: format ‘%d’ expects argument of type ‘int’, but argument 4
    has type ‘uintptr_t’ {aka ‘long unsigned int’} [-Wformat=]
      118 |       pbuf += sprintf(pbuf, "%s = %d\n", counter_names[i], counters[i]);
          |                                   ~^                       ~~~~~~~~~~~
          |                                    |                               |
          |                                    int                             uintptr_t {aka long unsigned int}

Use %lu for to print uintptr_t.