### PR TITLE
benchmarks: illegal addend for R_RISCV_GOT_HI20 in crt.S

### DIFF
--- a/benchmarks/common/crt.S
+++ b/benchmarks/common/crt.S
@@ -116,7 +116,8 @@ _start:
   la gp, __global_pointer$
 .option pop
 
-  la  tp, _end + 63
+  la  tp, _end
+  addi tp, tp, 63
   and tp, tp, -64
 
   # get core id

--- a/isa/rv64mi/illegal.S
+++ b/isa/rv64mi/illegal.S
@@ -34,7 +34,8 @@ bad2:
 test_vectored_interrupts:
   csrwi mip, MIP_SSIP
   csrwi mie, MIP_SSIP
-  la t0, mtvec_handler + 1
+  la t0, mtvec_handler
+  addi t0, t0, 1
   csrrw s0, mtvec, t0
   csrr t0, mtvec
   andi t0, t0, 1


### PR DESCRIPTION
With Ubuntu's GCC 15.2.0-7ubuntu1 building results in an error:

    /tmp/ccfCpSVm.o: in function `_start':
    (.text.init+0x100): dangerous relocation:
    The addend isn't allowed for R_RISCV_GOT_HI20

Split loading _end + 63 into register tp into separate load and add instructions.

https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc only describes R_RISCV_GOT_HI20 with offset 0 to a label.

The topic of addends for R_RISCV_GOT_HI20 was discussed in https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/184#issuecomment-830988778