### PR TITLE
benchmarks: undefined reference to `__printf_chk'

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -54,7 +54,7 @@ bmarks = $(base_bmarks) $(vec_bmarks)
 
 RISCV_PREFIX ?= riscv$(XLEN)-unknown-elf-
 RISCV_GCC ?= $(RISCV_PREFIX)gcc
-RISCV_GCC_OPTS ?= -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -Wno-implicit-int -Wno-implicit-function-declaration -mabi=$(ABI)
+RISCV_GCC_OPTS ?= -U_FORTIFY_SOURCE -DPREALLOCATE=1 -mcmodel=medany -static -std=gnu99 -O2 -ffast-math -fno-common -fno-builtin-printf -fno-tree-loop-distribute-patterns -Wno-implicit-int -Wno-implicit-function-declaration -mabi=$(ABI)
 RISCV_LINK ?= $(RISCV_GCC) -T $(src_dir)/common/test.ld $(incs)
 RISCV_LINK_OPTS ?= -static -nostdlib -nostartfiles -lm -lgcc -T $(src_dir)/common/test.ld
 RISCV_OBJDUMP ?= $(RISCV_PREFIX)objdump --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data


### PR DESCRIPTION
When building with Ubuntu's gcc 15.2.0-7ubuntu1 an error occurs:

    undefined reference to `__printf_chk'

This is due to _FORTIFY_SOURCE being set by the toolchain defaults.

Undefine the symbol.