### PR TITLE
Avoid RWX section

### DIFF
--- a/benchmarks/common/test.ld
+++ b/benchmarks/common/test.ld
@@ -18,18 +18,23 @@ ENTRY(_start)
 /* Sections                                                             */
 /*----------------------------------------------------------------------*/
 
+PHDRS
+{
+	text PT_LOAD FLAGS(SHF_ALLOC | SHF_EXECINSTR);
+}
+
 SECTIONS
 {
 
   /* text: test code section */
   . = 0x80000000;
-  .text.init : { *(.text.init) }
+  .text.init : { *(.text.init) } : text
 
   . = ALIGN(0x1000);
   .tohost : { *(.tohost) }
 
   . = ALIGN(0x1000);
-  .text : { *(.text) }
+  .text : { *(.text) } : text
 
   /* data segment */
   .data : { *(.data) }


### PR DESCRIPTION
Building leads to a warning

    riscv64-linux-gnu/bin/ld: warning:
    median.riscv has a LOAD segment with RWX permissions

The text sections should we RX only.