### PR TITLE
Fix the install target.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -17,8 +17,8 @@ all: benchmarks isa
 install: all
 	install -d $(instbasedir)/share/riscv-tests/isa
 	install -d $(instbasedir)/share/riscv-tests/benchmarks
-	install -p -m 644 `find isa -maxdepth 1 -type f` $(instbasedir)/share/riscv-tests/isa
-	install -p -m 644 `find benchmarks -maxdepth 1 -type f` $(instbasedir)/share/riscv-tests/benchmarks
+	install -p -m 644 `find isa -maxdepth 1 -type f \( -executable -o -name '*.dump' \)` $(instbasedir)/share/riscv-tests/isa
+	install -p -m 644 `find benchmarks -maxdepth 1 -type f \( -executable -o -name '*.dump' \)` $(instbasedir)/share/riscv-tests/benchmarks
 
 benchmarks:
 	mkdir -p benchmarks


### PR DESCRIPTION
Exclude incidental files from install, e.g. isa/{.gitignore,Makefile} and benchmarks/{Makefile,readme.txt}.