### PR TITLE
[debug] dscratch* registers should be ignored in DisconnectTest

### DIFF
--- a/debug/gdbserver.py
+++ b/debug/gdbserver.py
@@ -447,7 +447,7 @@ class DisconnectTest(GdbTest):
         regnames = set(old_values.keys()).union(set(new_values.keys()))
         for regname in regnames:
             if regname in ("mcycle", "minstret", "instret", "cycle", "mip",
-                    "time"):
+                    "time", "dscratch0", "dscratch1"):
                 continue
             assertEqual(old_values[regname], new_values[regname],
                     f"Register {regname} didn't match")


### PR DESCRIPTION
Dscratch* CSRs should be ignored in DisconnectTest because their value is not guaranteed to remain intact between abstract commands. See [1].

[1] https://docs.riscv.org/reference/debug/debug_module.html#dm-hartinfo

DisconnectTest would fail in `spike64-2.py` due to mainline OpenOCD commit [25b89a9](https://github.com/openocd-org/openocd/commit/25b89a97df2bcca30eb867ba2986bf36c9de6f7d)